### PR TITLE
feat: New workflow to upload build to s3

### DIFF
--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -1,0 +1,51 @@
+name: Upload action
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      short_commit:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      dist-folder:
+        required: false
+        type: string
+        default: 'dist'
+    secrets:
+      AWS_ACCOUNT:
+        required: true
+      AWS_REGION:
+        required: true
+      BUCKET_NAME:
+        required: true
+      BUCKET_PATH:
+        required: true
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubActionsRole
+          role-session-name: GithubActionsSession
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Download build artifact
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+      - name: Upload to s3
+        run: >
+          aws s3api put-object
+          --tagging commit=${{ inputs.short_commit }}
+          --bucket ${{ secrets.BUCKET_NAME }}
+          --key ${{ secrets.BUCKET_PATH }}/${{ inputs.artifact_name }}
+          --body ${{steps.download.outputs.download-path}}/${{ inputs.dist-folder }}

--- a/README.md
+++ b/README.md
@@ -20,8 +20,20 @@ The following workflows for NodeJS are in the `workflows` directory:
         - dist-folder. The location of the build file. This is usually configured in the package.json
         - retention-days. How many days to save the archive for if it's stored. Default 7 days.
         - build-command. What npm command is ran to build the project. Defaults to `package`.
+1. Upload to s3
+
+    Workflow downloads the archive created from the build workflow and pushes it to s3 with the commit id as a tag
+    - required arguments:
+        - environment. This is used for ensuring the correct secrets are being used
+        - short_commit. This is to tag the object with
+        - artifact-name. The name of the archive to store. For example `<branch-name>-<lambda-name>.zip`
+        - dist_folder. The location and name of the archive from the build step. For example, `package.zip`
+    - secrets:
+        - aws_account: the account number for the aws environment the archive is to be uploaded to.
+        - aws_region: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place
+        - bucket_name: The name of the bucket the archive is being uploaded to
+        - bucket_path: The bucket path or key of where the archive is being uploaded. Example: `lambda-archives/<lambda-name>`
 
 ## Coming soon
 
-- Upload to s3
 - Starter workflows


### PR DESCRIPTION
## Description

The workflow:
- Downloads the build archive using the name passed in
- Pushes archive to s3 with the passed in build name
- The bucket name and file path for the object are passed in
- The object is tagged with the short commit of the build

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
