### PR TITLE
fix: Fix env var for GitHub repo name

### DIFF
--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -57,4 +57,4 @@ jobs:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-      BUCKET_PATH: ${{ GITHUB_REPOSITORY }}
+      BUCKET_PATH: ${{ github.repository }}


### PR DESCRIPTION
## Description

- Used as placeholder for bucket path when uploading to s3

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
