### PR TITLE
fix: Remove `.zip` from pretty branch name

### DIFF
--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         id: branch
         run: |
           export PRETTY_BRANCH_NAME=$(tr '/' '-' <<< ${{ github.ref_name }})
-          echo "NAME=${PRETTY_BRANCH_NAME}.zip" >> $GITHUB_OUTPUT
+          echo "NAME=${PRETTY_BRANCH_NAME}" >> $GITHUB_OUTPUT
 
   build:
     uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2


### PR DESCRIPTION
## Description

- To stop duplicate `.zip` being appended to file names, remove from the pretty branch name var


Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
