### PR TITLE
feat: Added publish job step for optional downloading of previously built artefact

### DIFF
--- a/.github/workflows/nodejs-publish.yaml
+++ b/.github/workflows/nodejs-publish.yaml
@@ -7,6 +7,18 @@ on:
         required: false
         type: string
         default: '16.x'
+      download_artifact:
+        required: false
+        type: boolean
+        default: false
+      build_folder:
+        required: false
+        type: string
+        default: 'package'
+      build_folder_path:
+        required: false
+        type: string
+        default: 'dist'
     secrets:
       NPM_AUTH_TOKEN:
         required: true
@@ -21,6 +33,12 @@ jobs:
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
+      - name: Download build artifact
+        if: inputs.download_artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.build_folder }}
+          path: ${{ inputs.build_folder_path }}
       - name: Publish to npm.js
         run: npm publish --access=public
         env:

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Driver and Vehicle Standards Agency  Shared resources for all teams.
 
 ## Versions
 
-Currently on Version2.2
+Currently on Version2.3
 
 ```yaml
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
 ```
 
 If using the first version of the workflows, specify v1.0.0.
@@ -159,7 +159,7 @@ The build and upload-to-s3 steps would have the following inputs:
       build_command: build:prod
 
   upload-to-s3:
-    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2
+    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2.3
     with:
       environment: dev
       short_commit: ${{ needs.build-names.outputs.short_sha }}
@@ -195,7 +195,7 @@ The upload-to-s3 action with a matrix strategy defined:
 
 ```YAML
   upload-to-s3:
-    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2
+    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2.3
     strategy:
       matrix:
         buildName: [

--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -5,13 +5,13 @@ on:
 
 jobs:
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.3
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -33,7 +33,7 @@ jobs:
           echo "NAME=${PRETTY_BRANCH_NAME}" >> $GITHUB_OUTPUT
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
     needs: [ build-names ]
     with:
       upload_artifact: ${{ github.ref_name == 'main' }}
@@ -42,7 +42,7 @@ jobs:
 
   upload-to-s3:
     if: ${{ github.ref_name == github.event.repository.default_branch }}
-    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2.3
     needs: [ lint, test, build, build-names ]
     with:
       environment: dev
@@ -58,7 +58,7 @@ jobs:
 
   update-lambda-code:
     if: ${{ github.ref_name == github.event.repository.default_branch }}
-    uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v2.3
     needs: [ build-names, build, upload-s3 ]
     with:
       environment: dev

--- a/workflow-templates/npm-publish.yaml
+++ b/workflow-templates/npm-publish.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.1
+    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.3
     with:
       node-version: '16.x'
     secrets:


### PR DESCRIPTION
## Description
- Step is optional and is triggered by using upload_artifact flag in workflow
- When triggering, build_folder and build_folder_path can also be passed in to direct action
- Updated npm-publish.yaml template to run with latest version of workflows
- Updated workflows to run with new release version
- Updated documentation with new release version

Related issue: [RSP-2105](https://dvsa.atlassian.net/browse/RSP-2105?atlOrigin=eyJpIjoiYWRkNGQ2MzRhMjQxNDI2M2FlZTRkMWM5MWJlNDQ0MTgiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
