### PR TITLE
feat! VOL-3681: Default node version 18.x, input name refactor, increased configurability of workflows

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -20,7 +20,9 @@ runs:
         node-version: ${{ inputs.node_version }}
         cache: 'npm'
     - run: node --version
+      shell: bash
     - run: npm --version
+      shell: bash
 
     - name: Cache dependencies
       uses: actions/cache@v3

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -5,11 +5,7 @@ inputs:
   node_version:
     description: Node version used to install dependencies
     required: false
-    default: '16.16'
-  npm_version:
-    description: NPM version used to install dependencies
-    required: false
-    default: 'latest'
+    default: '18.x'
 
 runs:
   using: 'composite'

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -13,7 +13,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version: ${{ inputs.node_version }}
         cache: 'npm'
     - run: npm i -g npm@latest
       shell: bash

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -19,8 +19,8 @@ runs:
       with:
         node-version: ${{ inputs.node_version }}
         cache: 'npm'
-    - run: npm i -g npm@${{ inputs.npm_version }}
-      shell: bash
+    - run: node --version
+    - run: npm --version
 
     - name: Cache dependencies
       uses: actions/cache@v3

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -1,11 +1,17 @@
 name: Install dependencies
-description: install all project dependencies.
+description: Install Node, NPM and all project dependencies.
 
 inputs:
-  node_version:
+  node-version:
     description: Node version used to install dependencies
+    type: string
     required: false
     default: '18.x'
+  npm-version:
+    description: NPM version to be installed and used
+    type: string
+    required: false
+    default: 'latest'
 
 runs:
   using: 'composite'
@@ -13,8 +19,10 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ inputs.node_version }}
+        node-version: ${{ inputs.node-version }}
         cache: 'npm'
+    - run: npm i -g npm@${{ inputs.npm-version }}
+      shell: bash
     - run: node --version
       shell: bash
     - run: npm --version

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: Node version used to install dependencies
     required: false
     default: '16.16'
+  npm_version:
+    description: NPM version used to install dependencies
+    required: false
+    default: 'latest'
 
 runs:
   using: 'composite'
@@ -15,7 +19,7 @@ runs:
       with:
         node-version: ${{ inputs.node_version }}
         cache: 'npm'
-    - run: npm i -g npm@latest
+    - run: npm i -g npm@${{ inputs.npm_version }}
       shell: bash
 
     - name: Cache dependencies

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -2,7 +2,7 @@ name: Install dependencies
 description: install all project dependencies.
 
 inputs:
-  node-version:
+  node_version:
     description: Node version used to install dependencies
     required: false
     default: '16.16'

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -43,11 +43,11 @@ jobs:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}
       - name: Build
-        run: ${{ inputs.build_command }}
+        run: ${{ inputs.build-command }}
       - name: Upload artifact
-        if: inputs.upload_artifact
+        if: inputs.upload-artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ inputs.build_folder }}
-          path: ${{ inputs.build_folder_path }}
-          retention-days: ${{ inputs.retention_days }}
+          name: ${{ inputs.build-folder }}
+          path: ${{ inputs.build-folder-path }}
+          retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -26,9 +26,7 @@ on:
       node_version:
         required: false
         type: string
-      npm_version:
-        required: false
-        type: string
+        default: '18.x'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
+        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node_version: ${{ inputs.node_version }}
           npm_version: ${{ inputs.npm_version }}

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -37,7 +37,6 @@ jobs:
         uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node_version: ${{ inputs.node_version }}
-          npm_version: ${{ inputs.npm_version }}
       - name: Build
         run: ${{ inputs.build_command }}
       - name: Upload artifact

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -3,23 +3,23 @@ name: Build
 on:
   workflow_call:
     inputs:
-      upload_artifact:
+      upload-artifact:
         required: false
         type: boolean
         default: false
-      build_folder:
+      build-folder:
         required: false
         type: string
         default: 'dist'
-      build_folder_path:
+      build-folder-path:
         required: false
         type: string
         default: 'dist'
-      retention_days:
+      retention-days:
         required: false
         type: number
         default: 3
-      build_command:
+      build-command:
         required: false
         type: string
         default: 'npm run package'

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
+        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@main
+        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node_version: ${{ inputs.node_version }}
       - name: Build

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -23,6 +23,9 @@ on:
         required: false
         type: string
         default: 'package'
+      node_version:
+        required: false
+        type: string
 
 jobs:
   build:
@@ -32,6 +35,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: dvsa/.github/.github/actions/install-deps@main
+        with:
+          node_version: ${{ inputs.node_version }}
       - name: Build
         run: npm run ${{ inputs.build_command }}
       - name: Upload artifact

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -26,7 +26,9 @@ on:
       node_version:
         required: false
         type: string
-
+      npm_version:
+        required: false
+        type: string
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,6 +39,7 @@ jobs:
         uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node_version: ${{ inputs.node_version }}
+          npm_version: ${{ inputs.npm_version }}
       - name: Build
         run: npm run ${{ inputs.build_command }}
       - name: Upload artifact

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
+        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -22,7 +22,7 @@ on:
       build_command:
         required: false
         type: string
-        default: 'package'
+        default: 'npm run package'
       node_version:
         required: false
         type: string
@@ -41,7 +41,7 @@ jobs:
           node_version: ${{ inputs.node_version }}
           npm_version: ${{ inputs.npm_version }}
       - name: Build
-        run: npm run ${{ inputs.build_command }}
+        run: ${{ inputs.build_command }}
       - name: Upload artifact
         if: inputs.upload_artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -23,10 +23,14 @@ on:
         required: false
         type: string
         default: 'npm run package'
-      node_version:
-        required: false
+      node-version:
         type: string
+        required: false
         default: '18.x'
+      npm-version:
+        type: string
+        required: false
+        default: 'latest'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,7 +40,8 @@ jobs:
       - name: Install dependencies
         uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
-          node_version: ${{ inputs.node_version }}
+          node-version: ${{ inputs.node-version }}
+          npm-version: ${{ inputs.npm-version }}
       - name: Build
         run: ${{ inputs.build_command }}
       - name: Upload artifact

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -10,9 +10,7 @@ on:
       node_version:
         required: false
         type: string
-      npm_version:
-        required: false
-        type: string
+        default: '18.x'
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -20,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
+        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node_version: ${{ inputs.node_version }}
           npm_version: ${{ inputs.npm_version }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@main
+        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node_version: ${{ inputs.node_version }}
       - name: Lint

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -7,6 +7,9 @@ on:
         required: false
         type: number
         default: 0
+      node_version:
+        required: false
+        type: string
 
 jobs:
   lint:
@@ -16,5 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: dvsa/.github/.github/actions/install-deps@main
+        with:
+          node_version: ${{ inputs.node_version }}
       - name: Lint
         run: npm run lint -- --max-warnings ${{ inputs.max-warnings }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
+        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -3,7 +3,7 @@ name: Lint
 on:
   workflow_call:
     inputs:
-      max-warnings:
+      max_warnings:
         required: false
         type: number
         default: 0
@@ -23,4 +23,4 @@ jobs:
           node_version: ${{ inputs.node_version }}
           npm_version: ${{ inputs.npm_version }}
       - name: Lint
-        run: npm run lint -- --max-warnings ${{ inputs.max-warnings }}
+        run: npm run lint -- --max-warnings ${{ inputs.max_warnings }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -3,14 +3,18 @@ name: Lint
 on:
   workflow_call:
     inputs:
-      max_warnings:
+      max-warnings:
         required: false
         type: number
         default: 0
-      node_version:
-        required: false
+      node-version:
         type: string
+        required: false
         default: '18.x'
+      npm-version:
+        type: string
+        required: false
+        default: 'latest'
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -20,6 +24,7 @@ jobs:
       - name: Install dependencies
         uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
-          node_version: ${{ inputs.node_version }}
+          node-version: ${{ inputs.node-version }}
+          npm-version: ${{ inputs.npm-version }}
       - name: Lint
-        run: npm run lint -- --max-warnings ${{ inputs.max_warnings }}
+        run: npm run lint -- --max-warnings ${{ inputs.max-warnings }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -21,6 +21,5 @@ jobs:
         uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node_version: ${{ inputs.node_version }}
-          npm_version: ${{ inputs.npm_version }}
       - name: Lint
         run: npm run lint -- --max-warnings ${{ inputs.max_warnings }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
+        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -10,7 +10,9 @@ on:
       node_version:
         required: false
         type: string
-
+      npm_version:
+        required: false
+        type: string
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -21,5 +23,6 @@ jobs:
         uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node_version: ${{ inputs.node_version }}
+          npm_version: ${{ inputs.npm_version }}
       - name: Lint
         run: npm run lint -- --max-warnings ${{ inputs.max-warnings }}

--- a/.github/workflows/nodejs-publish.yaml
+++ b/.github/workflows/nodejs-publish.yaml
@@ -3,19 +3,19 @@ name: Publish
 on:
   workflow_call:
     inputs:
-      node_version:
-        required: false
+      node-version:
         type: string
+        required: false
         default: '18.x'
-      download_artifact:
+      download-artifact:
         required: false
         type: boolean
         default: false
-      build_folder:
+      build-folder:
         required: false
         type: string
         default: 'package'
-      build_folder_path:
+      build-folder-path:
         required: false
         type: string
         default: 'dist'
@@ -31,17 +31,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build on Node.js ${{ inputs.node_version }}
+      - name: Build on Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.node_version }}
+          node-version: ${{ inputs.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - name: Download build artifact
-        if: inputs.download_artifact
+        if: inputs.download-artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.build_folder }}
-          path: ${{ inputs.build_folder_path }}
+          name: ${{ inputs.build-folder }}
+          path: ${{ inputs.build-folder-path }}
       - name: Publish to npm.js
         run: npm publish ${{ inputs.args }}
         env:

--- a/.github/workflows/nodejs-publish.yaml
+++ b/.github/workflows/nodejs-publish.yaml
@@ -6,7 +6,7 @@ on:
       node_version:
         required: false
         type: string
-        default: '16.x'
+        default: '18.x'
       download_artifact:
         required: false
         type: boolean

--- a/.github/workflows/nodejs-security.yaml
+++ b/.github/workflows/nodejs-security.yaml
@@ -5,7 +5,7 @@ on:
       args:
         required: false
         type: string
-      continue_on_error:
+      continue-on-error:
         required: false
         type: boolean
         default: false
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
-        continue-on-error: ${{ inputs.continue_on_error }}
+        continue-on-error: ${{ inputs.continue-on-error }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/nodejs-security.yaml
+++ b/.github/workflows/nodejs-security.yaml
@@ -5,7 +5,6 @@ on:
       args:
         required: false
         type: string
-        default: '--dev --all-projects'
       continue-on-error:
         required: false
         type: boolean

--- a/.github/workflows/nodejs-security.yaml
+++ b/.github/workflows/nodejs-security.yaml
@@ -5,7 +5,7 @@ on:
       args:
         required: false
         type: string
-      continue-on-error:
+      continue_on_error:
         required: false
         type: boolean
         default: false
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
-        continue-on-error: ${{ inputs.continue-on-error }}
+        continue-on-error: ${{ inputs.continue_on_error }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/nodejs-security.yaml
+++ b/.github/workflows/nodejs-security.yaml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: '--dev --all-projects'
+      continue-on-error:
+        required: false
+        type: boolean
+        default: false
     secrets:
       SNYK_TOKEN:
         required: true
@@ -17,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
-        continue-on-error: false
+        continue-on-error: ${{ inputs.continue-on-error }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -10,9 +10,7 @@ on:
       node_version:
         required: false
         type: string
-      npm_version:
-        required: false
-        type: string
+        default: '18.x'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -20,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
+        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node_version: ${{ inputs.node_version }}
           npm_version: ${{ inputs.npm_version }}

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -10,7 +10,9 @@ on:
       node_version:
         required: false
         type: string
-
+      npm_version:
+        required: false
+        type: string
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,5 +23,6 @@ jobs:
         uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node_version: ${{ inputs.node_version }}
+          npm_version: ${{ inputs.npm_version }}
       - name: Test
         run: npm run ${{ inputs.test_command }}

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@main
+        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
+        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -21,6 +21,5 @@ jobs:
         uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node_version: ${{ inputs.node_version }}
-          npm_version: ${{ inputs.npm_version }}
       - name: Test
         run: npm run ${{ inputs.test_command }}

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@feature/VOL-3681-node-version-definable
+        uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -3,14 +3,18 @@ name: Test
 on:
   workflow_call:
     inputs:
-      test_command:
+      test-command:
         required: false
         type: string
-        default: 'test'
-      node_version:
+        default: 'npm run test'
+      node-version:
         required: false
         type: string
         default: '18.x'
+      npm-version:
+        required: false
+        type: string
+        default: 'latest'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -20,6 +24,7 @@ jobs:
       - name: Install dependencies
         uses: dvsa/.github/.github/actions/install-deps@v3.0.0
         with:
-          node_version: ${{ inputs.node_version }}
+          node-version: ${{ inputs.node-version }}
+          npm-version: ${{ inputs.npm-version }}
       - name: Test
-        run: npm run ${{ inputs.test_command }}
+        run: ${{ inputs.test-command }}

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -7,6 +7,9 @@ on:
         required: false
         type: string
         default: 'test'
+      node_version:
+        required: false
+        type: string
 
 jobs:
   test:
@@ -16,5 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: dvsa/.github/.github/actions/install-deps@main
+        with:
+          node_version: ${{ inputs.node_version }}
       - name: Test
         run: npm run ${{ inputs.test_command }}

--- a/.github/workflows/update-lambda-function.yaml
+++ b/.github/workflows/update-lambda-function.yaml
@@ -11,16 +11,14 @@ on:
       bucket_key:
         required: true
         type: string
-      role_name_to_assume:
-        required: false
-        type: string
-        default: 'GithubActionsRole'
     secrets:
       AWS_ACCOUNT:
         required: true
       AWS_REGION:
         required: true
       BUCKET_NAME:
+        required: true
+      AWS_ROLE_TO_ASSUME_ARN:
         required: true
 jobs:
   deploy:
@@ -32,7 +30,7 @@ jobs:
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.role_name_to_assume }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
           role-session-name: GithubActionsSession
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Update lambda function code

--- a/.github/workflows/update-lambda-function.yaml
+++ b/.github/workflows/update-lambda-function.yaml
@@ -11,6 +11,10 @@ on:
       bucket_key:
         required: true
         type: string
+      role_name_to_assume:
+        required: false
+        type: string
+        default: 'GithubActionsRole'
     secrets:
       AWS_ACCOUNT:
         required: true
@@ -28,7 +32,7 @@ jobs:
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubActionsRole
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.role_name_to_assume }}
           role-session-name: GithubActionsSession
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Update lambda function code

--- a/.github/workflows/update-lambda-function.yaml
+++ b/.github/workflows/update-lambda-function.yaml
@@ -5,10 +5,10 @@ on:
       environment:
         required: true
         type: string
-      lambda_function_name:
+      lambda-function-name:
         required: true
         type: string
-      bucket_key:
+      bucket-key:
         required: true
         type: string
     secrets:
@@ -34,4 +34,4 @@ jobs:
           role-session-name: GithubActionsSession
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Update lambda function code
-        run: aws lambda update-function-code --function-name ${{ inputs.lambda_function_name }} --s3-bucket "${{ secrets.BUCKET_NAME }}" --s3-key "${{ inputs.bucket_key }}" --publish --query FunctionName
+        run: aws lambda update-function-code --function-name ${{ inputs.lambda-function-name }} --s3-bucket "${{ secrets.BUCKET_NAME }}" --s3-key "${{ inputs.bucket-key }}" --publish --query FunctionName

--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -5,16 +5,16 @@ on:
       environment:
         required: true
         type: string
-      short_commit:
+      short-commit:
         required: true
         type: string
       artifact:
         required: true
         type: string
-      bucket_key:
+      bucket-key:
         required: true
         type: string
-      build_folder:
+      build-folder:
         required: false
         type: string
         default: dist
@@ -44,11 +44,11 @@ jobs:
         id: download
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.build_folder }}
+          name: ${{ inputs.build-folder }}
       - name: Upload to s3
         run: >
           aws s3api put-object
-          --tagging short_commit_id=${{ inputs.short_commit }}
+          --tagging short_commit_id=${{ inputs.short-commit }}
           --bucket ${{ secrets.BUCKET_NAME }}
-          --key ${{ inputs.bucket_key }}
+          --key ${{ inputs.bucket-key }}
           --body ${{steps.download.outputs.download-path}}/${{ inputs.artifact }}

--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: dist
+      role_name_to_assume:
+        required: false
+        type: string
+        default: 'GithubActionsRole'
     secrets:
       AWS_ACCOUNT:
         required: true
@@ -35,7 +39,7 @@ jobs:
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubActionsRole
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.role_name_to_assume }}
           role-session-name: GithubActionsSession
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Download build artifact

--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -18,14 +18,12 @@ on:
         required: false
         type: string
         default: dist
-      role_name_to_assume:
-        required: false
-        type: string
-        default: 'GithubActionsRole'
     secrets:
       AWS_ACCOUNT:
         required: true
       AWS_REGION:
+        required: true
+      AWS_ROLE_TO_ASSUME_ARN:
         required: true
       BUCKET_NAME:
         required: true
@@ -39,7 +37,7 @@ jobs:
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.role_name_to_assume }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
           role-session-name: GithubActionsSession
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Download build artifact

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
 
 1. Lint
     - optional argument:
-        - `max-warnings`: Sets how many warnings are allowed. Default is `0`.
+        - `max_warnings`: Sets how many warnings are allowed. Default is `0`.
+        - `node_version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
 1. Test
     - optional argument:
         - `test_command`: Sets the command used during the Test step. Default is `npm run test`.
+        - `node_version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
 1. Security
     - required secret `SNYK_TOKEN` requires the organization or repo snyk token secret
     - optional argument `args` allows passing in any extra args to the snyk command. Note, the default behavior is to test all projects including all dev dependencies. If you don't want to test dev dependencies, pass in args: `--all-projects` to override the default args.
@@ -41,7 +43,8 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
         - `build_folder`. The location of the build file. This is usually configured in the package.json or webpack config. Defaults to `dist`.
         - `build_folder_path`. If only a subset of directories want to be saved provide the path to those files. For example `dist/artifact`. Defaults to `dist`.
         - `retention_days`. How many days to save the archive for if it's stored. (upload-artifact: `true`). Default is `7` days.
-        - build-command. The npm command to run to build the project. Defaults to `package`.
+        - `build_command`. The command to run to build the project. Defaults to `npm run package`.
+        - `node_version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
 1. Upload to s3
 
     Workflow downloads the archive created from the build workflow and pushes it to s3 with the commit id as a tag. Default only running on master branch. See examples before for more information.
@@ -54,9 +57,10 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
     - optional arguments:
         - `build_folder`. The name of the folder where the archive zip is located. For example `dist`. This is used to download the archive that was uploaded during the build step. Defaults to `dist`.
     - secrets:
-        - `aws_account`: the account number for the aws environment the archive is to be uploaded to.
-        - `aws_region`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place
-        - `bucket_name`: The name of the bucket the archive is being uploaded to
+        - `AWS_ACCOUNT`: the account number for the aws environment the archive is to be uploaded to.
+        - `AWS_REGION`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place.
+        - `BUCKET_NAME`: The name of the bucket the archive is being uploaded to.
+        - `AWS_ROLE_TO_ASSUME_ARN`: The ARN for the role assume when uploading the archive to S3.
 1. Update Lambda Function Code
 
     Workflow to update the Lambda on AWS to use the newly updated code from S3.
@@ -78,7 +82,7 @@ To read about using Starter Workflows, see [here](https://docs.github.com/en/act
 
 1. Publish
     - optional arguments:
-        - `node-version`: The version of Node the package is to be published with. This is defaulted to the latest version of NodeJS 16.
+        - `node_version`: The version of Node the package is to be published with. This is defaulted to the latest version of NodeJS 18.
         - `download_artifact`: Optional boolean value, to be used when building package separately prior to publishing.
         - `build_folder`: The folder to download the built package from.
         - `build_folder_path`: The path of the folder to download the built package to.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Driver and Vehicle Standards Agency  Shared resources for all teams.
 
 ## Versions
 
-Currently on Version2.3
+Currently on Version 3.0.0
 
 ```yaml
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v3.0.0
 ```
 
 If using the first version of the workflows, specify v1.0.0.
@@ -26,36 +26,39 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
 
 1. Lint
     - optional argument:
-        - `max_warnings`: Sets how many warnings are allowed. Default is `0`.
-        - `node_version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
+        - `max-warnings`: Sets how many warnings are allowed. Default is `0`.
+        - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
+        - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
 1. Test
     - optional argument:
-        - `test_command`: Sets the command used during the Test step. Default is `npm run test`.
-        - `node_version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
+        - `test-command`: Sets the command used during the Test step. Default is `npm run test`.
+        - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
+        - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
 1. Security
     - required secret `SNYK_TOKEN` requires the organization or repo snyk token secret
     - optional argument `args` allows passing in any extra args to the snyk command. Note, the default behavior is to test all projects including all dev dependencies. If you don't want to test dev dependencies, pass in args: `--all-projects` to override the default args.
 1. Build
     - required arguments:
-        - `artifact_name`: The name of the archive to store.
+        - `artifact-name`: The name of the archive to store.
     - optional arguments:
-        - `upload_artifact`. If true the build archive will be stored in github. Defaults to `false` if the archive doesn't need to be saved. Must be true if upload to s3 is required.
-        - `build_folder`. The location of the build file. This is usually configured in the package.json or webpack config. Defaults to `dist`.
-        - `build_folder_path`. If only a subset of directories want to be saved provide the path to those files. For example `dist/artifact`. Defaults to `dist`.
-        - `retention_days`. How many days to save the archive for if it's stored. (upload-artifact: `true`). Default is `7` days.
-        - `build_command`. The command to run to build the project. Defaults to `npm run package`.
-        - `node_version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
+        - `upload-artifact`. If true the build archive will be stored in github. Defaults to `false` if the archive doesn't need to be saved. Must be true if upload to s3 is required.
+        - `build-folder`. The location of the build file. This is usually configured in the package.json or webpack config. Defaults to `dist`.
+        - `build-folder-path`. If only a subset of directories want to be saved provide the path to those files. For example `dist/artifact`. Defaults to `dist`.
+        - `retention-days`. How many days to save the archive for if it's stored. (upload-artifact: `true`). Default is `7` days.
+        - `build-command`. The command to run to build the project. Defaults to `npm run package`.
+        - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
+        - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
 1. Upload to s3
 
     Workflow downloads the archive created from the build workflow and pushes it to s3 with the commit id as a tag. Default only running on master branch. See examples before for more information.
 
     - required arguments:
         - `environment`. This is used for ensuring the correct secrets are being used
-        - `short_commit`. This is to tag the object with
+        - `short-commit`. This is to tag the object with
         - `artifact`. The name of the archive from the build step. For example, `package.zip`.
-        - `bucket_key`: The file name and path in s3 where the object should be uploaded to. See [s3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html).
+        - `bucket-key`: The file name and path in s3 where the object should be uploaded to. See [s3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html).
     - optional arguments:
-        - `build_folder`. The name of the folder where the archive zip is located. For example `dist`. This is used to download the archive that was uploaded during the build step. Defaults to `dist`.
+        - `build-folder`. The name of the folder where the archive zip is located. For example `dist`. This is used to download the archive that was uploaded during the build step. Defaults to `dist`.
     - secrets:
         - `AWS_ACCOUNT`: the account number for the aws environment the archive is to be uploaded to.
         - `AWS_REGION`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place.
@@ -67,12 +70,12 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
 
     - required arguments:
         - `environment`. This is used for ensuring the correct secrets are being used
-        - `lambda_function_name`. The name of the Lambda function to update
-        - `bucket_key`: The file name and path in s3 where the object should be uploaded to. See [s3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html).
+        - `lambda-function-name`. The name of the Lambda function to update
+        - `bucket-key`: The file name and path in s3 where the object should be uploaded to. See [s3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html).
     - secrets:
-        - `aws_account`: the account number for the aws environment the archive is to be uploaded to.
-        - `aws_region`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place
-        - `bucket_name`: The name of the bucket the archive is being uploaded to
+        - `AWS_ACCOUNT`: the account number for the aws environment the archive is to be uploaded to.
+        - `AWS_REGION`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place
+        - `BUCKET_NAME`: The name of the bucket the archive is being uploaded to
 
 To read more about sharing workflows within the organization, see the [GitHub docs](https://docs.github.com/en/actions/using-workflows/sharing-workflows-secrets-and-runners-with-your-organization).
 
@@ -82,10 +85,10 @@ To read about using Starter Workflows, see [here](https://docs.github.com/en/act
 
 1. Publish
     - optional arguments:
-        - `node_version`: The version of Node the package is to be published with. This is defaulted to the latest version of NodeJS 18.
-        - `download_artifact`: Optional boolean value, to be used when building package separately prior to publishing.
-        - `build_folder`: The folder to download the built package from.
-        - `build_folder_path`: The path of the folder to download the built package to.
+        - `node_-version`: The version of Node the package is to be published with. This is defaulted to the latest version of NodeJS 18.
+        - `download-artifact`: Optional boolean value, to be used when building package separately prior to publishing.
+        - `build-folder`: The folder to download the built package from.
+        - `build-folder-path`: The path of the folder to download the built package to.
         - `args`: optional arguments for the npm publish command, such as --dry-run or --access=public.
     - secrets:
         - `NPM_AUTH_TOKEN`: the authorisation token to be used to publish the package to the NPMJS site. 


### PR DESCRIPTION
## Description

Allows a consumer of workflows to define the node version when building, linting, testing and packaging; set to the latest LTS (18). Additionally, allows a consumer to define a role ARN to assume when interating with AWS S3 and Lambda Code Update. Increased configurability of workflows.

Related issue: [VOL-3681](https://dvsa.atlassian.net/browse/VOL-3681)

## Update Notes

> **This has breaking changes to default behaviours, values and interfaces; to be tagged/released as a major vesion.**

### Default Node Version

The default Node version for all workflows is now `18.x`. Can be overriden by specifying `node-version`.

### Changes to action/install-deps

1. Introduced optional input `npm-version` (default `latest`) which defined the version of NPM to be installed.
2. The default value for input `node-version` used has changed from `16.16` to `18.x`.
3. The action allows users to specify the version of **npm**.
4. The action will now print out the version of node and npm used.

### Changes to workflows/nodejs-build

1. Introduced optional input `node-version` (default `18.x`) which is passed through to subsequent `action/install-deps`.
2. Introduced optional input `npm-version` (default `latest`) which is passed through to subsequent `action/install-deps`.
3. The input for `upload_artifact` has been renamed to `upload-artifact` inline with currrent standard used in this repository.
4. The input for `build_folder` has been renamed to `build-folder` inline with currrent standard used in this repository.
5. The input for `build_folder_path` has been renamed to `build-folder-path` inline with currrent standard used in this repository.
6. The input for `retention_days` has been renamed to `retention-days` inline with currrent standard used in this repository.
7. The input for `build_command` has been renamed to `build-command` inline with currrent standard used in this repository.
8. The default value for input `build-command` used has changed from `package` to `npm run package`.
9. The workflow allows defintion of a full command instead of being restricted to `npm run X`; allowing for prefixing environment variables and additional flexability when executing a build command.

### Changes to workflows/nodejs-lint

1. Introduced optional input `node-version` (default `18.x`) which is passed through to subsequent `action/install-deps`.
2. Introduced optional input `npm-version` (default `latest`) which is passed through to subsequent `action/install-deps`.

### Changes to workflows/nodejs-publish

1. The input for `node_version` has been renamed to `node-version` inline with currrent standard used in this repository.
2. The default value for input `node-version` used has changed from `16.16` to `18.x`.
3. The input for `download_artifact` has been renamed to `download-artifact` inline with currrent standard used in this repository.
4. The input for `build_folder` has been renamed to `build-folder` inline with currrent standard used in this repository.
5. The input for `build_folder_path` has been renamed to `build-folder-path` inline with currrent standard used in this repository.


### Changes to workflows/nodejs-security

1. The default value for input `args` has been changed from `--dev --all-projects` to undefined/empty.
6. Introduced optional input `continue-on-error` (default `false`) which is passed through to subsequent `snyk/actions/node`.
7. `continue-on-error` is now configurable via input instead of hardcoded `false`.

### Changes to workflows/nodejs-test

1. The input for `test_command` has been renamed to `test-command` inline with currrent standard used in this repository.
2. The default value for input `test-command` used has changed from `package` to `npm run package`.
3. The workflow allows defintion of a full command instead of being restricted to `npm run X`; allowing for prefixing environment variables and additional flexability when executing a build command.
4. Introduced optional input `node-version` (default `18.x`) which is passed through to subsequent `action/install-deps`.
5. Introduced optional input `npm-version` (default `latest`) which is passed through to subsequent `action/install-deps`.

### Changes to workflows/update-lambda-function

1. The input for `lambda_function_name` has been renamed to `lambda-function-name` inline with currrent standard used in this repository.
2. The input for `bucket_key` has been renamed to `bucket-key` inline with currrent standard used in this repository.
3. Introduction of required secret `AWS_ROLE_TO_ASSUME_ARN` which dermines the assumed role when updating lambda function code.
4. The workflow no longer uses a static role to assume (`role/GithubActionsRole` on the specified secret `AWS_ACCOUNT`), instead a ARN is required via the secret `AWS_ROLE_TO_ASSUME_ARN`; allowing for greater flexibility with roles and cross account operations.

### Changes to workflows/upload-to-s3

1. The input for `short_commit` has been renamed to `short-commit` inline with currrent standard used in this repository.
2. The input for `bucket_key` has been renamed to `bucket-key` inline with currrent standard used in this repository.
3. The input for `build_folder` has been renamed to `build-folder` inline with currrent standard used in this repository.
4. Introduction of required secret `AWS_ROLE_TO_ASSUME_ARN` which dermines the assumed role when putting objects into an S3 bucket.
5. The workflow no longer uses a static role to assume (`role/GithubActionsRole` on the specified secret `AWS_ACCOUNT`), instead a ARN is required via the secret `AWS_ROLE_TO_ASSUME_ARN`; allowing for greater flexibility with roles and cross account operations.

### README Updates

Updated the README.md to reflect changes, and specify default version to use is `v3.0.0`




## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
