### PR TITLE
feat: RSP-2091 Optional tags in S3 Upload

### DIFF
--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -8,6 +8,10 @@ on:
       short-commit:
         required: true
         type: string
+      optional-tags:
+        required: false
+        type: string
+        default: ''
       artifact:
         required: true
         type: string
@@ -48,7 +52,7 @@ jobs:
       - name: Upload to s3
         run: >
           aws s3api put-object
-          --tagging short_commit_id=${{ inputs.short-commit }}
+          --tagging 'short_commit_id=${{ inputs.short-commit }}&${{ inputs.optional-tags }}'
           --bucket ${{ secrets.BUCKET_NAME }}
           --key ${{ inputs.bucket-key }}
           --body ${{steps.download.outputs.download-path}}/${{ inputs.artifact }}

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
     - required arguments:
         - `artifact-name`: The name of the archive to store.
     - optional arguments:
-        - `upload-artifact`. If true the build archive will be stored in github. Defaults to `false` if the archive doesn't need to be saved. Must be true if upload to s3 is required.
-        - `build-folder`. The location of the build file. This is usually configured in the package.json or webpack config. Defaults to `dist`.
-        - `build-folder-path`. If only a subset of directories want to be saved provide the path to those files. For example `dist/artifact`. Defaults to `dist`.
-        - `retention-days`. How many days to save the archive for if it's stored. (upload-artifact: `true`). Default is `7` days.
-        - `build-command`. The command to run to build the project. Defaults to `npm run package`.
+        - `upload-artifact`: If true the build archive will be stored in github. Defaults to `false` if the archive doesn't need to be saved. Must be true if upload to s3 is required.
+        - `build-folder`: The location of the build file. This is usually configured in the package.json or webpack config. Defaults to `dist`.
+        - `build-folder-path`: If only a subset of directories want to be saved provide the path to those files. For example `dist/artifact`. Defaults to `dist`.
+        - `retention-days`: How many days to save the archive for if it's stored. (upload-artifact: `true`). Default is `7` days.
+        - `build-command`: The command to run to build the project. Defaults to `npm run package`.
         - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
         - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
 1. Upload to s3
@@ -86,7 +86,7 @@ To read about using Starter Workflows, see [here](https://docs.github.com/en/act
 
 1. Publish
     - optional arguments:
-        - `node_-version`: The version of Node the package is to be published with. This is defaulted to the latest version of NodeJS 18.
+        - `node-version`: The version of Node the package is to be published with. This is defaulted to the latest version of NodeJS 18.
         - `download-artifact`: Optional boolean value, to be used when building package separately prior to publishing.
         - `build-folder`: The folder to download the built package from.
         - `build-folder-path`: The path of the folder to download the built package to.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
         - `bucket-key`: The file name and path in s3 where the object should be uploaded to. See [s3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html).
     - optional arguments:
         - `build-folder`: The name of the folder where the archive zip is located. For example `dist`. This is used to download the archive that was uploaded during the build step. Defaults to `dist`.
-        - `optional-tags`: Additional tags to be applied to the object. These must be in URL query form, for example `Key1=Value1`. Multiple tags MUST be joined with an &, for example `Key1=Value1&Key2=Value2`. See documentation linked above for further information.
+        - `optional-tags`: Additional tags to be applied to the object. These must be in URL query form, for example `Key1=Value1`. Multiple tags MUST be joined with an &, for example `Key1=Value1&Key2=Value2`. See put-object tagging [documentation](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html) for more information.
     - secrets:
         - `AWS_ACCOUNT`: the account number for the aws environment the archive is to be uploaded to.
         - `AWS_REGION`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # .github
 
-Driver and Vehicle Standards Agency  Shared resources for all teams.
+Driver and Vehicle Standards Agency - Shared resources for all teams.
 
 ## Versions
 
-Currently on Version 3.0.0
+Currently on Version 3.1.0
 
 ```yaml
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v3.0.0
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v3.1.0
 ```
 
 If using the first version of the workflows, specify v1.0.0.
@@ -35,8 +35,8 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
         - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
         - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
 1. Security
-    - required secret `SNYK_TOKEN` requires the organization or repo snyk token secret
-    - optional argument `args` allows passing in any extra args to the snyk command. Note, the default behavior is to test all projects including all dev dependencies. If you don't want to test dev dependencies, pass in args: `--all-projects` to override the default args.
+    - required secret `SNYK_TOKEN` requires the organization or repo Snyk token secret
+    - optional argument `args` allows passing in any extra args to the Snyk command. Note, the default behavior is to test all projects including all dev dependencies. If you don't want to test dev dependencies, pass in args: `--all-projects` to override the default args.
 1. Build
     - required arguments:
         - `artifact-name`: The name of the archive to store.
@@ -53,12 +53,13 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
     Workflow downloads the archive created from the build workflow and pushes it to s3 with the commit id as a tag. Default only running on master branch. See examples before for more information.
 
     - required arguments:
-        - `environment`. This is used for ensuring the correct secrets are being used
-        - `short-commit`. This is to tag the object with
-        - `artifact`. The name of the archive from the build step. For example, `package.zip`.
+        - `environment`: This is used for ensuring the correct secrets are being used.
+        - `short-commit`: The short commit ID of the related commit, which is tagged to the object in S3.
+        - `artifact`: The name of the archive from the build step. For example, `package.zip`.
         - `bucket-key`: The file name and path in s3 where the object should be uploaded to. See [s3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html).
     - optional arguments:
-        - `build-folder`. The name of the folder where the archive zip is located. For example `dist`. This is used to download the archive that was uploaded during the build step. Defaults to `dist`.
+        - `build-folder`: The name of the folder where the archive zip is located. For example `dist`. This is used to download the archive that was uploaded during the build step. Defaults to `dist`.
+        - `optional-tags`: Additional tags to be applied to the object. These must be in URL query form, for example `Key1=Value1`. Multiple tags MUST be joined with an &, for example `Key1=Value1&Key2=Value2`. See documentation linked above for further information.
     - secrets:
         - `AWS_ACCOUNT`: the account number for the aws environment the archive is to be uploaded to.
         - `AWS_REGION`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place.
@@ -69,13 +70,13 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
     Workflow to update the Lambda on AWS to use the newly updated code from S3.
 
     - required arguments:
-        - `environment`. This is used for ensuring the correct secrets are being used
-        - `lambda-function-name`. The name of the Lambda function to update
+        - `environment`: This is used for ensuring the correct secrets are being used.
+        - `lambda-function-name`: The name of the Lambda function to update.
         - `bucket-key`: The file name and path in s3 where the object should be uploaded to. See [s3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html).
     - secrets:
         - `AWS_ACCOUNT`: the account number for the aws environment the archive is to be uploaded to.
-        - `AWS_REGION`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place
-        - `BUCKET_NAME`: The name of the bucket the archive is being uploaded to
+        - `AWS_REGION`: the account region for the aws environment the archive is to be upgraded to. It's easier to maintain if this is only set in one place.
+        - `BUCKET_NAME`: The name of the bucket the archive is being uploaded to.
 
 To read more about sharing workflows within the organization, see the [GitHub docs](https://docs.github.com/en/actions/using-workflows/sharing-workflows-secrets-and-runners-with-your-organization).
 


### PR DESCRIPTION
## Description

- When implementing lifecycle policies on objects in RSP S3 buckets, it became apparent the best way to do this would be via tags.
- This change adds an optional input, which can be used to pass tags (in URL query form) to the S3 upload command.
- The tagging parameter has been wrapped in single quotes, and an & added to allow the chaining of tags.
- README has been updated to epxlain how to use the new input, as well as making some other general punctuation fixes.

Related issue: [RSP-2091](https://dvsa.atlassian.net/browse/RSP-2091)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
