### PR TITLE
ci: escape user input in workflow

### DIFF
--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -21,6 +21,8 @@ jobs:
     outputs:
       short_sha: ${{ steps.sha.outputs.SHORT_SHA }}
       pretty_branch_name: ${{ steps.branch.outputs.NAME }}
+    env:
+      BRANCH_NAME: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
       - name: Set short sha output
@@ -29,7 +31,7 @@ jobs:
       - name: Set archive name output
         id: branch
         run: |
-          export PRETTY_BRANCH_NAME=$(tr '/' '-' <<< ${{ github.ref_name }})
+          export PRETTY_BRANCH_NAME=$(tr '/' '-' <<< "$BRANCH_NAME")
           echo "NAME=${PRETTY_BRANCH_NAME}" >> $GITHUB_OUTPUT
 
   build:


### PR DESCRIPTION
Fixes the possible script injection in the workflow `ci.yaml`

Proof of concept and before/after fix below. Tested against workflow and the previously proposed composite action.

**Before:**
https://github.com/dvsa/mot-history/actions/runs/4736332321

**After:**
https://github.com/dvsa/mot-history/actions/runs/4736437785