### PR TITLE
Bump `configure-aws-credentials` to v2

### DIFF
--- a/.github/actions/aws-auth/action.yml
+++ b/.github/actions/aws-auth/action.yml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:        
   - name: Infra AWS Authenication 
-    uses: aws-actions/configure-aws-credentials@v1-node16
+    uses: aws-actions/configure-aws-credentials@v2
     with:
       role-to-assume: "arn:aws:iam::${{ inputs.aws_account_id }}:role/${{ inputs.aws_role }}" #
       aws-region: "${{ inputs.aws_region }}"

--- a/.github/workflows/update-lambda-function.yaml
+++ b/.github/workflows/update-lambda-function.yaml
@@ -28,7 +28,7 @@ jobs:
       id-token: write
     steps:
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
           role-session-name: GithubActionsSession

--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -39,7 +39,7 @@ jobs:
       id-token: write
     steps:
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
           role-session-name: GithubActionsSession


### PR DESCRIPTION
## Description

Removes the following deprecations:

> ***Warning***
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

and...
> ***Warning***
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.