### PR TITLE
feat: add workflow template to validate PR title

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,3 +544,10 @@ to
  uses: dvsa/.github/.github/workflows/php-library-tests.yml@v3.2.3
 
 ```
+
+## The `check-pr-title.yaml` starter workflow
+
+This workflow will check the title of a pull request and ensure it follows the conventional commit specification.
+
+> **Warning**
+> This workflow should only be used if `commitlint` is already configured in the repository.

--- a/workflow-templates/check-pr-title.json
+++ b/workflow-templates/check-pr-title.json
@@ -1,0 +1,6 @@
+{
+    "name": "Check PR title",
+    "description": "Enforces conventional commit messages in the PR titles",
+    "iconName": "octicon git-pull-request",
+    "categories": ["Automation"]
+}

--- a/workflow-templates/check-pr-title.yaml
+++ b/workflow-templates/check-pr-title.yaml
@@ -1,0 +1,29 @@
+name: Check PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm ci
+      - name: Validate PR title
+        run: echo "$TITLE" | npx commitlint


### PR DESCRIPTION
## Description

Add workflow template to verify a PR title follows the [conventional commit specification](https://www.conventionalcommits.org/en/about/).

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
