### PR TITLE
feat: php-*tests allows definition of optional config and php-*static/tests support php versions

### DIFF
--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -10,11 +10,11 @@ on:
       php-version:
         required: false
         type: string
-        default: '8.1'
+        default: 'latest'
   
 jobs:
   phpstan:
-    name: PHPStan - ${{ inputs.php-version }}
+    name: PHPStan - ${{ inputs.php-version }} - ${{ matrix.stability }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -39,7 +39,7 @@ jobs:
 
   php-codesniffer:
    
-    name: PHP-CodeSniffer - ${{ inputs.php-version }}
+    name: PHP-CodeSniffer - ${{ inputs.php-version }} - ${{ matrix.stability }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -64,7 +64,7 @@ jobs:
 
   psalm:
     
-    name: Psalm - ${{ inputs.php-version }}
+    name: Psalm - ${{ inputs.php-version }} - ${{ matrix.stability }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}

--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -7,6 +7,18 @@ on:
         required: false
         default: true
         type: boolean
+      phpstan-composer-install:
+        required: false
+        default: false
+        type: boolean
+      phpcs-composer-install:
+        required: false
+        default: false
+        type: boolean
+      psalm-composer-install:
+        required: false
+        default: true
+        type: boolean
   
 jobs:
   phpstan:
@@ -27,6 +39,10 @@ jobs:
           coverage: none
           tools: phpstan
 
+      - name: Setup composer
+        if: ${{ phpstan-composer-install }}
+        run: composer install --no-progress
+
       - name: Execute PHPStan
         run: phpstan analyze --no-progress
 
@@ -45,6 +61,11 @@ jobs:
           php-version: latest
           coverage: none
           tools: php-cs-fixer, phpcs
+
+      - name: Setup composer
+        if: ${{ phpcs-composer-install }}
+        run: composer install --no-progress
+
       - name: Execute PHP CodeSniffer
         run: phpcs -q
 
@@ -69,8 +90,8 @@ jobs:
           tools: vimeo/psalm
           
       - name: Setup composer
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-
+        if: ${{ psalm-composer-install }}
+        run: composer install --no-progress
 
       - name: Execute Psalm
         run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}

--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup composer
         if: ${{ phpstan-composer-install }}
-        run: composer install --no-progress
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute PHPStan
         run: phpstan analyze --no-progress
@@ -91,7 +91,7 @@ jobs:
           
       - name: Setup composer
         if: ${{ psalm-composer-install }}
-        run: composer install --no-progress
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute Psalm
         run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}

--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -7,18 +7,6 @@ on:
         required: false
         default: true
         type: boolean
-      phpstan-composer-install:
-        required: false
-        default: false
-        type: boolean
-      phpcs-composer-install:
-        required: false
-        default: false
-        type: boolean
-      psalm-composer-install:
-        required: false
-        default: true
-        type: boolean
   
 jobs:
   phpstan:
@@ -39,8 +27,7 @@ jobs:
           coverage: none
           tools: phpstan
 
-      - name: Setup composer
-        if: ${{ phpstan-composer-install }}
+      - name: Install (Update) Composer dependancies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute PHPStan
@@ -50,7 +37,10 @@ jobs:
    
     name: PHP-CodeSniffer 
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: ${{ inputs.fail-fast }}
+      matrix:
+        stability: [prefer-lowest, prefer-stable]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -62,9 +52,8 @@ jobs:
           coverage: none
           tools: php-cs-fixer, phpcs
 
-      - name: Setup composer
-        if: ${{ phpcs-composer-install }}
-        run: composer install --no-progress
+      - name: Install (Update) Composer dependancies
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute PHP CodeSniffer
         run: phpcs -q
@@ -89,8 +78,7 @@ jobs:
           extensions: mbstring, intl
           tools: vimeo/psalm
           
-      - name: Setup composer
-        if: ${{ psalm-composer-install }}
+      - name: Install (Update) Composer dependancies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute Psalm

--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -7,10 +7,14 @@ on:
         required: false
         default: true
         type: boolean
+      php-version:
+        required: false
+        type: string
+        default: '8.1'
   
 jobs:
   phpstan:
-    name: PHPStan 
+    name: PHPStan - ${{ inputs.php-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -23,7 +27,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: latest
+          php-version: ${{ inputs.php-version }}
           coverage: none
           tools: phpstan
 
@@ -35,7 +39,7 @@ jobs:
 
   php-codesniffer:
    
-    name: PHP-CodeSniffer 
+    name: PHP-CodeSniffer - ${{ inputs.php-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -48,7 +52,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: latest
+          php-version: ${{ inputs.php-version }}
           coverage: none
           tools: php-cs-fixer, phpcs
 
@@ -60,7 +64,7 @@ jobs:
 
   psalm:
     
-    name: Psalm 
+    name: Psalm - ${{ inputs.php-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -73,7 +77,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: latest
+          php-version: ${{ inputs.php-version }}
           coverage: none
           extensions: mbstring, intl
           tools: vimeo/psalm

--- a/.github/workflows/php-library-tests.yml
+++ b/.github/workflows/php-library-tests.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
       phpunit-args:
         required: false
-        default: --verbose
+        default: '--verbose'
         type: string
 
 jobs:
@@ -41,4 +41,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit ${{ phpunit-args }}
+        run: vendor/bin/phpunit ${{ inputs.phpunit-args }}

--- a/.github/workflows/php-library-tests.yml
+++ b/.github/workflows/php-library-tests.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: true
         type: boolean
-      phpunit-config:
+      phpunit-config-file:
         required: false
         type: string
 
@@ -26,7 +26,7 @@ jobs:
     name: PHP test ${{ matrix.php }}
 
     env:
-      PHPUNIT_CONFIG: ${{ inputs.phpunit-config && format('-c {0}', inputs.phpunit-config) || '' }}
+      PHPUNIT_CONFIG_FILE: ${{ inputs.phpunit-config-file && format('-c "{0}"', inputs.phpunit-config-file) || '' }}
 
     steps:
       - name: Checkout code
@@ -43,4 +43,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit $PHPUNIT_CONFIG
+        run: vendor/bin/phpunit $PHPUNIT_CONFIG_FILE

--- a/.github/workflows/php-library-tests.yml
+++ b/.github/workflows/php-library-tests.yml
@@ -10,9 +10,8 @@ on:
         required: false
         default: true
         type: boolean
-      phpunit-args:
+      phpunit-config:
         required: false
-        default: '--verbose'
         type: string
 
 jobs:
@@ -24,7 +23,10 @@ jobs:
       matrix:
         php: ${{ fromJSON(inputs.php-versions) }}
         stability: [prefer-lowest, prefer-stable]
-    name: PHP test ${{ matrix.php }} 
+    name: PHP test ${{ matrix.php }}
+
+    env:
+      PHPUNIT_CONFIG: ${{ inputs.phpunit-config && format('-c "{0}"', inputs.phpunit-config) || '' }}
 
     steps:
       - name: Checkout code
@@ -41,4 +43,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit ${{ inputs.phpunit-args }}
+        run: vendor/bin/phpunit $PHPUNIT_CONFIG

--- a/.github/workflows/php-library-tests.yml
+++ b/.github/workflows/php-library-tests.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: true
         type: boolean
+      phpunit-args:
+        required: false
+        default: --verbose
+        type: string
 
 jobs:
   tests:
@@ -37,4 +41,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit ${{ phpunit-args }}

--- a/.github/workflows/php-library-tests.yml
+++ b/.github/workflows/php-library-tests.yml
@@ -26,7 +26,7 @@ jobs:
     name: PHP test ${{ matrix.php }}
 
     env:
-      PHPUNIT_CONFIG: ${{ inputs.phpunit-config && format('-c "{0}"', inputs.phpunit-config) || '' }}
+      PHPUNIT_CONFIG: ${{ inputs.phpunit-config && format('-c {0}', inputs.phpunit-config) || '' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/php-static.yml
+++ b/.github/workflows/php-static.yml
@@ -26,7 +26,7 @@ jobs:
           tools: phpstan
 
       - name: Install Composer dependancies
-        run: composer install --no-progress
+        run: composer install --no-progress --no-interaction
 
       - name: Execute PHPStan
         run: phpstan analyze --no-progress
@@ -48,7 +48,7 @@ jobs:
           tools: php-cs-fixer, phpcs
 
       - name: Install Composer dependancies
-        run: composer install --no-progress
+        run: composer install --no-progress --no-interaction
 
       - name: Execute PHP CodeSniffer
         run: phpcs -q
@@ -71,7 +71,7 @@ jobs:
           tools: vimeo/psalm
           
       - name: Install Composer dependancies
-        run: composer install --no-progress
+        run: composer install --no-progress --no-interaction
 
       - name: Execute Psalm
         run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}

--- a/.github/workflows/php-static.yml
+++ b/.github/workflows/php-static.yml
@@ -2,19 +2,6 @@ name: Static analysis
 
 on:
   workflow_call:
-    inputs:
-      phpstan-composer-install:
-        required: false
-        default: false
-        type: boolean
-      phpcs-composer-install:
-        required: false
-        default: false
-        type: boolean
-      psalm-composer-install:
-        required: false
-        default: true
-        type: boolean
 
 jobs:
   phpstan:
@@ -33,8 +20,7 @@ jobs:
           coverage: none
           tools: phpstan
 
-      - name: Setup composer
-        if: ${{ phpstan-composer-install }}
+      - name: Install Composer dependancies
         run: composer install --no-progress
 
       - name: Execute PHPStan
@@ -56,8 +42,7 @@ jobs:
           coverage: none
           tools: php-cs-fixer, phpcs
 
-      - name: Setup composer
-        if: ${{ phpcs-composer-install }}
+      - name: Install Composer dependancies
         run: composer install --no-progress
 
       - name: Execute PHP CodeSniffer
@@ -80,8 +65,7 @@ jobs:
           extensions: mbstring, intl
           tools: vimeo/psalm
           
-      - name: Setup composer
-        if: ${{ psalm-composer-install }}
+      - name: Install Composer dependancies
         run: composer install --no-progress
 
       - name: Execute Psalm

--- a/.github/workflows/php-static.yml
+++ b/.github/workflows/php-static.yml
@@ -1,7 +1,20 @@
 name: Static analysis
 
 on:
- workflow_call:
+  workflow_call:
+    inputs:
+      phpstan-composer-install:
+        required: false
+        default: false
+        type: boolean
+      phpcs-composer-install:
+        required: false
+        default: false
+        type: boolean
+      psalm-composer-install:
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   phpstan:
@@ -19,6 +32,10 @@ jobs:
           php-version: '8.1'
           coverage: none
           tools: phpstan
+
+      - name: Setup composer
+        if: ${{ phpstan-composer-install }}
+        run: composer install --no-progress
 
       - name: Execute PHPStan
         run: phpstan analyze --no-progress
@@ -38,6 +55,11 @@ jobs:
           php-version: '8.1'
           coverage: none
           tools: php-cs-fixer, phpcs
+
+      - name: Setup composer
+        if: ${{ phpcs-composer-install }}
+        run: composer install --no-progress
+
       - name: Execute PHP CodeSniffer
         run: phpcs -q
 
@@ -59,6 +81,7 @@ jobs:
           tools: vimeo/psalm
           
       - name: Setup composer
+        if: ${{ psalm-composer-install }}
         run: composer install --no-progress
 
       - name: Execute Psalm

--- a/.github/workflows/php-static.yml
+++ b/.github/workflows/php-static.yml
@@ -6,7 +6,7 @@ on:
       php-version:
         required: false
         type: string
-        default: '8.1'
+        default: 'latest'
 
 jobs:
   phpstan:

--- a/.github/workflows/php-static.yml
+++ b/.github/workflows/php-static.yml
@@ -2,11 +2,16 @@ name: Static analysis
 
 on:
   workflow_call:
+    inputs:
+      php-version:
+        required: false
+        type: string
+        default: '8.1'
 
 jobs:
   phpstan:
    
-    name: PHPStan 
+    name: PHPStan - ${{ inputs.php-version }}
     runs-on: ubuntu-latest
 
     steps:
@@ -16,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs.php-version }}
           coverage: none
           tools: phpstan
 
@@ -28,7 +33,7 @@ jobs:
 
   php-codesniffer:
    
-    name: PHP-CodeSniffer - '8.1'
+    name: PHP-CodeSniffer - ${{ inputs.php-version }}
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +43,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs.php-version }}
           coverage: none
           tools: php-cs-fixer, phpcs
 
@@ -50,7 +55,7 @@ jobs:
 
   psalm:
     
-    name: Psalm - '8.1'
+    name: Psalm - ${{ inputs.php-version }}
     runs-on: ubuntu-latest
 
     steps:
@@ -60,7 +65,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs.php-version }}
           coverage: none
           extensions: mbstring, intl
           tools: vimeo/psalm

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,9 +10,8 @@ on:
         required: false
         default: true
         type: boolean
-      phpunit-args:
+      phpunit-config:
         required: false
-        default: '--verbose'
         type: string
 
 jobs:
@@ -25,6 +24,9 @@ jobs:
         php: ${{ fromJSON(inputs.php-versions) }}
         
     name: PHP test ${{ matrix.php }} 
+
+    env:
+      PHPUNIT_CONFIG: ${{ inputs.phpunit-config && format('-c "{0}"', inputs.phpunit-config) || '' }}
 
     steps:
       - name: Checkout code
@@ -41,4 +43,4 @@ jobs:
         run: composer install --optimize-autoloader --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit ${{ inputs.phpunit-args }}
+        run: vendor/bin/phpunit $PHPUNIT_CONFIG

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: true
         type: boolean
-      phpunit-config:
+      phpunit-config-file:
         required: false
         type: string
 
@@ -26,7 +26,7 @@ jobs:
     name: PHP test ${{ matrix.php }} 
 
     env:
-      PHPUNIT_CONFIG: ${{ inputs.phpunit-config && format('-c "{0}"', inputs.phpunit-config) || '' }}
+      PHPUNIT_CONFIG_FILE: ${{ inputs.phpunit-config-file && format('-c "{0}"', inputs.phpunit-config-file) || '' }}
 
     steps:
       - name: Checkout code
@@ -43,4 +43,4 @@ jobs:
         run: composer install --optimize-autoloader --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit $PHPUNIT_CONFIG
+        run: vendor/bin/phpunit $PHPUNIT_CONFIG_FILE

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: true
         type: boolean
+      phpunit-args:
+        required: false
+        default: '--verbose'
+        type: string
 
 jobs:
   tests:
@@ -37,4 +41,4 @@ jobs:
         run: composer install --optimize-autoloader --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit ${{ inputs.phpunit-args }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -40,7 +40,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --optimize-autoloader --no-progress
+        run: composer install --optimize-autoloader --no-progress --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit $PHPUNIT_CONFIG_FILE

--- a/README.md
+++ b/README.md
@@ -562,3 +562,4 @@ Secrets:
 Inputs:
 * [REQUIRED] `php-version` - list of strings of all php versions which the workflow will run against
 * [OPTIONAL] `fail-fast` - boolean to control whether all steps in the matrix should be run, even if one of them fails
+* [OPTIONAL] `phpunit-args` - string of arguments to be appended to the invocation of `vendor/bin/phpunit` (default is `--verbose` as per existing behaviour, however as of PHPUnit 10, this will no longer work and will need overriding to an empty string, or other arguments of choice)

--- a/README.md
+++ b/README.md
@@ -562,4 +562,4 @@ Secrets:
 Inputs:
 * [REQUIRED] `php-version` - list of strings of all php versions which the workflow will run against
 * [OPTIONAL] `fail-fast` - boolean to control whether all steps in the matrix should be run, even if one of them fails
-* [OPTIONAL] `phpunit-config` - the phpunit configuration file to use with `vendor/bin/phpunit`, default is empty/not defined thus resorting to default behaviour when a configuration file (`-c` or `--configuration`) is not specified. 
+* [OPTIONAL] `phpunit-config-file` - the phpunit configuration file to use with `vendor/bin/phpunit`, default is empty/not defined thus resorting to default behaviour when a configuration file (`-c` or `--configuration`) is not specified. 

--- a/README.md
+++ b/README.md
@@ -562,4 +562,4 @@ Secrets:
 Inputs:
 * [REQUIRED] `php-version` - list of strings of all php versions which the workflow will run against
 * [OPTIONAL] `fail-fast` - boolean to control whether all steps in the matrix should be run, even if one of them fails
-* [OPTIONAL] `phpunit-args` - string of arguments to be appended to the invocation of `vendor/bin/phpunit` (default is `--verbose` as per existing behaviour, however as of PHPUnit 10, this will no longer work and will need overriding to an empty string, or other arguments of choice)
+* [OPTIONAL] `phpunit-config` - the phpunit configuration file to use with `vendor/bin/phpunit`, default is empty/not defined thus resorting to default behaviour when a configuration file (`-c` or `--configuration`) is not specified. 


### PR DESCRIPTION
Default args is to use --verbose as per existing functionality; as not to break or change existing workflows.

## Description

- Update php-[library-]tests.yml to allow for optional configuration file to be defined when running phpunit.
- Update php-[library-]static.yml to allow specification of PHP version.
- Static (library) analysis workflow jobs will always install **and update** (using stability matrix: prefer-lowest, prefer-stable) composer dependancies.
- Static analysis workflow jobs will always install composer dependancies.

Removed `--verbose` flag as when running phpunit.

### But why?

PHPUnit 10 does not support the argument `--verbose` any longer.

https://github.com/sebastianbergmann/phpunit/blob/c4c60c34c0e92045afce938510f8878d7cd84f8a/ChangeLog-10.0.md

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
  https://github.com/dvsa/dvsa-config-generator/actions/runs/6088779782
- [x] Did you make sure to update any documentation relating to this change?
