### PR TITLE
Add auxiliary workflows related to container & images

### DIFF
--- a/.github/actions/image-integrity/README.md
+++ b/.github/actions/image-integrity/README.md
@@ -1,0 +1,33 @@
+# Image Signature Creation & Validation Using AWS Signer
+Action to generate or inspect image sign
+
+####  Prerequisites
+AWS Signer Profile with required ECR permissions need to be configured
+
+####  Context
+This action allows the workflow to build VOL API artifact
+
+####  Inputs
+- aws_signer_profile_arn (optional): AWS Signer Profile ARN if `image_sign_create` is set to `true`
+- ecr_tagged_image (required): AWS ECR Image: {ACCOUNT_ID}.dkr.ecr.{REGION}.amazonaws.com/{REPO_NAME}:{IMAGE_TAG}
+- image_sign_create (optional): Sign image if `true`
+- image_sign_inspect (optional): 'Inspect sign if `true`
+
+####  Outputs
+N/A
+
+####  Usage     
+```yaml
+- name: Create image sign
+  uses: dvsa/.github/.github/actions/image-integrity@main
+  with:
+    ecr_tagged_image: ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${REPO_NAME}:${IMAGE_TAG}
+    image_sign_inspect: 'true'
+
+- name: Inspect image sign
+  uses: dvsa/.github/.github/actions/image-integrity@main
+  with:
+    aws_signer_profile_arn: ${ aws_signer_profile }
+    ecr_tagged_image: ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${REPO_NAME}:${IMAGE_TAG}
+    image_sign_inspect: 'true'      
+```

--- a/.github/actions/image-integrity/action.yaml
+++ b/.github/actions/image-integrity/action.yaml
@@ -1,0 +1,50 @@
+name: Validate AWS ECR Image Signature
+description: Validate AWS ECR Image Signature
+
+inputs:
+  aws_signer_profile_arn:
+    description: 'AWS Signer Profile ARN if `image_sign_create` is set to `true`'
+    required: false
+  ecr_tagged_image:
+    description: 'AWS ECR Image: {ACCOUNT_ID}.dkr.ecr.{REGION}.amazonaws.com/{REPO_NAME}:{IMAGE_TAG}'
+    required: true
+  image_sign_create:
+    description: 'Sign image if `true`'
+    required: true
+    default: 'false'
+  image_sign_inspect:
+    description: 'Inspect sign if `true`'
+    required: true
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps: 
+    - name: Login to ECR
+      id: login-to-ecr
+      uses: aws-actions/amazon-ecr-login@v2.0.1
+
+    - name: Setup Notation CLI
+      uses: notaryproject/notation-action/setup@v1
+      with:
+        version: 1.0.0
+
+    - name: Set up Notation AWS Signer plugin
+      run: |
+        wget https://d2hvyiie56hcat.cloudfront.net/linux/amd64/installer/deb/latest/aws-signer-notation-cli_amd64.deb
+        sudo dpkg -i aws-signer-notation-cli_amd64.deb
+      shell: bash
+
+    - name: Sign image
+      if: inputs.image_sign_create == 'true'
+      run: |
+        notation sign ${{ inputs.ecr_tagged_image }} \
+          --plugin "com.amazonaws.signer.notation.plugin" \
+          --id "${{ inputs.aws_signer_profile_arn }}"
+      shell: bash
+
+    - name: Validate signature of image
+      if: inputs.image_sign_inspect == 'true'
+      run: |
+        notation inspect ${{ inputs.ecr_tagged_image }}
+      shell: bash

--- a/.github/actions/terraform-action/README.md
+++ b/.github/actions/terraform-action/README.md
@@ -8,7 +8,7 @@ Authenticated with AWS Account
 This action allows the workflow to run terraform commands via TF Scaffold
 
 ####  Inputs
-- action (required): Terraform action to run e.g plan.
+- action (required): Comma-separated list of terraform actions to run e.g plan | init,plan,apply.
 - project (required): Terraform project e.g dvsa <project_name>.
 - environment (required): Terraform environment e.g dev.
 - component (required): Terraform component to deploy e.g db.

--- a/.github/actions/terraform-action/action.yml
+++ b/.github/actions/terraform-action/action.yml
@@ -2,7 +2,7 @@ name: Terraform Action
 
 inputs: 
   action: 
-    description: 'Terraform action to run e.g plan'
+    description: 'Comma-separated list of terraform actions to run e.g plan | init,plan,apply'
     required: true
     type: string
   project: 
@@ -41,7 +41,7 @@ inputs:
 runs:
   using: 'composite'
   steps: 
-    - uses: hashicorp/setup-terraform@v2
+    - uses: hashicorp/setup-terraform@v3.0.0
       with:
         terraform_version:  ${{ inputs.terraform_version }}      
         terraform_wrapper: false
@@ -49,13 +49,11 @@ runs:
     - name: Terraform init and plan
       id: plan
       run: |
-        mkdir -p plans/${{ inputs.environment }}
-        ./bin/terraform.sh --action ${{ inputs.action }} --project ${{ inputs.project }} --environment ${{ inputs.environment }}  --component ${{ inputs.component }} --group ${{ inputs.group }} --bucket-prefix ${{ inputs.bucket-prefix }} --region ${{ inputs.region }} --compact-warnings --no-color -- ${{ inputs.terraform_args }} | tee plans/${{ inputs.environment }}/${{ inputs.component }}-plan.txt
+        actionList=($(echo ${{ inputs.action }} | tr "," " "))
+        for action in "${actionList[@]}"; do
+          ./bin/terraform.sh --action ${action} \
+            --project ${{ inputs.project }} --environment ${{ inputs.environment }} \
+            --component ${{ inputs.component }} --group ${{ inputs.group }} \
+            --region ${{ inputs.region }} --bucket-prefix ${{ inputs.bucket-prefix }}
+        done
       shell: bash
-
-    - name: Save Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: "${{ inputs.environment }}-${{ inputs.component }}"
-        path: "./plans/${{ inputs.environment }}/${{ inputs.component }}-plan.txt"
-        retention-days: 7

--- a/.github/actions/terraform-fmt/action.yml
+++ b/.github/actions/terraform-fmt/action.yml
@@ -21,7 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: hashicorp/setup-terraform@v2
+
+    - name: Checkout the repository to the runner
+      uses: actions/checkout@v3
+
+    - uses: hashicorp/setup-terraform@v3.0.0
       with:
         terraform_version: ${{ inputs.terraform_version }}
     - run: |
@@ -32,5 +36,6 @@ runs:
           echo "RECURSIVE='-recursive'" >> $GITHUB_ENV
           fi
       shell: bash
+
     - run: terraform fmt ${{ env.CHECK }} ${{ env.RECURSIVE }} ${{ inputs.path }}
       shell: bash

--- a/.github/actions/terraform-snyk/README.md
+++ b/.github/actions/terraform-snyk/README.md
@@ -1,0 +1,25 @@
+# Terraform Synk Scan
+Action to run Terraform Synk Scan
+
+####  Prerequisites
+N/A
+
+####  Context
+Run Snyk Scan on Terraform Code
+
+####  Inputs
+snyk_token (required): Snyk Token
+terraform_version (optional): Terraform Version
+
+
+####  Outputs
+N/A
+
+####  Usage     
+```yaml
+- name: Terraform Snyk Scan
+  uses: dvsa/.github/.github/actions/terraform-snyk@main
+  with:
+    terraform_version: 1.5.5
+    snyk_token: xyz123
+```

--- a/.github/actions/terraform-snyk/action.yml
+++ b/.github/actions/terraform-snyk/action.yml
@@ -1,0 +1,29 @@
+name: Terraform Synk Scan
+
+inputs:
+  terraform_version:
+    required: false
+    type: string
+    description: Terraform version
+    default: '1.3.7'
+  snyk_token:
+    required: true
+    type: string
+    description: Value of snyk token
+  
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: hashicorp/setup-terraform@v3.0.0
+      with:
+        terraform_version: ${{ inputs.terraform_version }}
+
+    - name: Run Snyk to check for vulnerabilities
+      id: snyk
+      uses: snyk/actions/iac@master
+      env:
+        SNYK_TOKEN: ${{ inputs.snyk_token }}
+      with:
+        args: scan .
+      continue-on-error: true

--- a/.github/actions/terraform-tfsec/README.md
+++ b/.github/actions/terraform-tfsec/README.md
@@ -1,0 +1,26 @@
+# Terraform Security Scan
+Action to run Terraform tfsec Scan
+
+####  Prerequisites
+N/A
+
+####  Context
+Run tfsec on Terraform Code
+
+####  Inputs
+github_token (required): GitHub Token
+terraform_version (optional): Terraform Version
+path (required): Target directory to run tfsec
+
+
+####  Outputs
+N/A
+
+####  Usage     
+```yaml
+- name: Terraform tfsec Scan
+  uses: dvsa/.github/.github/actions/terraform-tfsec@main
+  with:
+    terraform_version: 1.5.5
+    path: components/*
+```

--- a/.github/actions/terraform-tfsec/action.yml
+++ b/.github/actions/terraform-tfsec/action.yml
@@ -1,0 +1,56 @@
+name: Terraform Security Scan
+
+inputs:
+  github_token:
+    required: true
+    type: string
+  terraform_version:
+    required: false
+    type: string
+    description: Terraform version
+    default: '1.3.7'
+  path:
+    required: false
+    type: string
+    description: Target directory in which to run tfsec command
+    default: 'components/'
+  
+
+runs:
+  using: 'composite'
+  steps:
+
+    - name: Checkout the repository to the runner
+      uses: actions/checkout@v3
+
+    - name: Setup Terraform with specified version on the runner
+      uses: hashicorp/setup-terraform@v3.0.0
+      with:
+        terraform_version: ${{ inputs.terraform_version }}
+
+    - name: Terraform init
+      id: init
+      run: terraform init
+      shell: bash
+
+    - name: Group all .tf files under target directory
+      run: |
+        find ${{ inputs.path }} -mindepth 2 -type f \
+          -print -exec cp -r {} ${{ inputs.path }} \;
+        ls -la ${{ inputs.path }}
+      shell: bash
+      
+    - name: Terraform Security scanning tfsec
+      id: tfsec
+      uses: aquasecurity/tfsec-action@v1.0.3
+      with:
+        working_directory: ${{ inputs.path }}
+        additional_args: -e .terraform --concise-output --out .tfsec_output
+        # format: sarif
+        soft_fail: true
+        github_token: '${{ inputs.github_token }}'
+        
+    - name: Print concise output of tfsec scan
+      run: |
+        cat .tfsec_output
+      shell: bash

--- a/.github/workflows/docker-hadolint.yaml
+++ b/.github/workflows/docker-hadolint.yaml
@@ -1,0 +1,34 @@
+name: Dockerfile Lint Check
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile_name:
+        description: 'Name of Dockerfile'
+        default: 'dockerfile'
+        required: true
+        type: string
+      supress_rule_list:
+        description: 'Comma-separated list of lint rules to ignore, e.g. DL3048,DL3018'
+        default: ''
+        required: false
+        type: string
+
+jobs:
+  hadolint:
+    
+    name: Run hadolint on Dockerfile
+    runs-on: ubuntu-latest
+    
+    steps:
+
+      - name: Checkout the repository to the runner
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.ref }}
+
+      - name: Lint check on dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ${{ inputs.dockerfile_name }}
+          ignore: ${{ inputs.supress_rule_list }}

--- a/.github/workflows/trigger-github-workflow.yaml
+++ b/.github/workflows/trigger-github-workflow.yaml
@@ -1,0 +1,61 @@
+name: Trigger GH Actions Workflow
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Name of the branch which contains the given Workflow'
+        default: 'main'
+        required: true
+        type: string
+      git_repository:
+        description: 'Name of the Owner/Repo which contains the given Workflow'
+        default: 'Owner/Repo'
+        required: true
+        type: string
+      workflow_name:
+        description: 'Name of the given Workflow'
+        default: 'workflow.yaml'
+        required: true
+        type: string
+      input_arguments:
+        description: 'Input Arguments to the given Workflow'
+        default: 'input_argument=input_value'
+        required: true
+        type: string
+    secrets:
+      gh_token:
+        description: 'PAT for Workflow in other repository otherwise GITHUB_TOKEN'
+        required: true
+
+jobs:
+
+  trigger-workflow:
+
+    name: Trigger Workflow
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+
+    - name: Trigger Workflow
+      run: |
+        gh workflow run '${{ inputs.workflow_name }}' \
+          -R ${{ inputs.git_repository }} \
+          --ref ${{ inputs.branch }} \
+          -f ${{ inputs.input_arguments }}
+        sleep 60 # required to assign the run-id to workflow
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}
+    
+    - name: Monitor Workflow Execution Progress
+      run: |
+        runID=`curl -L -H \
+                "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.gh_token }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/${{ inputs.git_repository }}/actions/runs |\
+                jq -r '.workflow_runs[0]|select(.name == "${{ inputs.workflow_name }}" and .status == "in_progress").id'`
+        gh run watch $runID --interval 10 --exit-status 1  -R ${{ inputs.git_repository }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.gh_token }}


### PR DESCRIPTION
## Description

This PR contains 3 auxiliary actions & 2 workflows related to docker image integrity, lint check and deployment:
- `docker-hadolint.yaml`: Dockerfile lint check using `hadolint`
-  `trigger-github-workflow.yaml`: Trigger GH Actions workflow within the same or different repo
- `image-integrity`: Create & validate the signature of images stored on AWS ECR leveraging the utilities: AWS Signer & Notation
- `terraform-snyk`: Performs snyk scan on terraform code
- `terraform-tfsec`: Run `tfsec` scan on terraform code

`terraform-action` is also updated to allow multiple terraform actions. Minor updates were made in `terraform-fmt`.

Related issue: 
- [AWSRESET1-483](https://dvsa.atlassian.net/browse/AWSRESET1-483)
- [AWSRESET1-485](https://dvsa.atlassian.net/browse/AWSRESET1-485)
- [AWSRESET1-514](https://dvsa.atlassian.net/browse/AWSRESET1-514)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
