### PR TITLE
feat: Add `--no-transfer-progress` to `mvn` command

### DIFF
--- a/.github/workflows/java-test.yaml
+++ b/.github/workflows/java-test.yaml
@@ -79,6 +79,6 @@ jobs:
       - name: Run Unit Tests with Maven
         run: |
           aws configure set region eu-west-1
-          mvn clean test
+          mvn clean test --no-transfer-progress
         working-directory: ${{inputs.working-directory}}
         


### PR DESCRIPTION
## Description

<!--
Include a summary of the change here.
-->

Adds the `--no-transfer-progress` argument to the `mvn` command. This suppresses a huge amount of output showing the progress of dependency downloads ([15K lines on `smc-mot-service` as of the time of this PR](https://github.com/dvsa/smc-mot-service/actions/runs/7713213883/job/21022591253)), while still also providing useful error messages should a dependency fail to download.

Related issue: N/A

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
