### PR TITLE
Add required path param and toggles for tools to php-library-static

### DIFF
--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -3,6 +3,9 @@ name: Static analysis
 on:
   workflow_call:
     inputs:
+      path:
+        required: true
+        type: string
       fail-fast:
         required: false
         default: true
@@ -35,7 +38,7 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute PHPStan
-        run: phpstan analyze --no-progress
+        run: phpstan analyze --no-progress ${{ inputs.path }}
 
   php-codesniffer:
 
@@ -60,7 +63,7 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute PHP CodeSniffer
-        run: phpcs -q
+        run: phpcs -q ${{ inputs.path }}
 
   psalm:
 

--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -14,9 +14,22 @@ on:
         required: false
         type: string
         default: 'latest'
+      use-phpstan:
+        required: false
+        type: boolean
+        default: true
+      use-php-codesniffer:
+        required: false
+        type: boolean
+        default: true
+      use-psalm:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   phpstan:
+    if: ${{ inputs.use-phpstan }}
     name: PHPStan - ${{ inputs.php-version }} - ${{ matrix.stability }}
     runs-on: ubuntu-latest
     strategy:
@@ -41,7 +54,7 @@ jobs:
         run: phpstan analyze --no-progress ${{ inputs.path }}
 
   php-codesniffer:
-
+    if: ${{ inputs.use-php-codesniffer }}
     name: PHP-CodeSniffer - ${{ inputs.php-version }} - ${{ matrix.stability }}
     runs-on: ubuntu-latest
     strategy:
@@ -66,7 +79,7 @@ jobs:
         run: phpcs -q ${{ inputs.path }}
 
   psalm:
-
+    if: ${{ inputs.use-psalm }}
     name: Psalm - ${{ inputs.php-version }} - ${{ matrix.stability }}
     runs-on: ubuntu-latest
     strategy:
@@ -90,3 +103,4 @@ jobs:
 
       - name: Execute Psalm
         run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}
+

--- a/.github/workflows/php-library-tests.yml
+++ b/.github/workflows/php-library-tests.yml
@@ -13,6 +13,10 @@ on:
       phpunit-config-file:
         required: false
         type: string
+      phpunit-args:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   tests:
@@ -43,4 +47,5 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit $PHPUNIT_CONFIG_FILE
+        run: vendor/bin/phpunit ${{ inputs.phpunit-args }} $PHPUNIT_CONFIG_FILE
+


### PR DESCRIPTION
The php-library-static workflow currently does not work. This PR adds a new parameter to it to specify the path.

Additionally, it also adds specific toggles for each tool, and a phpunit-args parameter for the tests for use in https://github.com/dvsa/mot-api-client-php/pull/1

Related issue: https://dvsa.atlassian.net/browse/BL-16435

