### PR TITLE
feat: BL-17232 add composer version as input to php actions

### DIFF
--- a/.github/workflows/php-library-security.yml
+++ b/.github/workflows/php-library-security.yml
@@ -16,6 +16,10 @@ on:
       severity-threshold:
         required: false
         type: string
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
 
 jobs:
   snyk:
@@ -38,7 +42,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2
+          tools: composer:${{ inputs.composer-version }}
           coverage: none
           extensions: mbstring
 

--- a/.github/workflows/php-library-static.yml
+++ b/.github/workflows/php-library-static.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: 'latest'
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
 
 jobs:
   phpstan:
@@ -29,7 +33,7 @@ jobs:
         with:
           php-version: ${{ inputs.php-version }}
           coverage: none
-          tools: phpstan
+          tools: phpstan, composer:${{ inputs.composer-version }}
 
       - name: Install (Update) Composer dependancies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress

--- a/.github/workflows/php-library-tests.yml
+++ b/.github/workflows/php-library-tests.yml
@@ -13,6 +13,10 @@ on:
       phpunit-config-file:
         required: false
         type: string
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
 
 jobs:
   tests:
@@ -36,7 +40,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2
+          tools: composer:${{ inputs.composer-version }}
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/php-security.yml
+++ b/.github/workflows/php-security.yml
@@ -9,6 +9,10 @@ on:
       severity-threshold:
         required: false
         type: string
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
 
 jobs:
  snyk:
@@ -28,6 +32,7 @@ jobs:
         php-version: 8.1
         coverage: none
         extensions: mbstring
+        tools: composer:${{ inputs.composer-version }}
 
     - name: Run Snyk to check for vulnerabilities
       uses: snyk/actions/php@master

--- a/.github/workflows/php-security.yml
+++ b/.github/workflows/php-security.yml
@@ -9,6 +9,10 @@ on:
       severity-threshold:
         required: false
         type: string
+      php-version:
+        required: false
+        type: string
+        default: 8.1
       composer-version:
         required: false
         type: string
@@ -29,7 +33,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: ${{ inputs.php-version }}
         coverage: none
         extensions: mbstring
         tools: composer:${{ inputs.composer-version }}

--- a/.github/workflows/php-static.yml
+++ b/.github/workflows/php-static.yml
@@ -7,6 +7,10 @@ on:
         required: false
         type: string
         default: 'latest'
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
 
 jobs:
   phpstan:
@@ -23,7 +27,7 @@ jobs:
         with:
           php-version: ${{ inputs.php-version }}
           coverage: none
-          tools: phpstan
+          tools: phpstan, composer:${{ inputs.composer-version }}
 
       - name: Install Composer dependancies
         run: composer install --no-progress --no-interaction
@@ -45,7 +49,7 @@ jobs:
         with:
           php-version: ${{ inputs.php-version }}
           coverage: none
-          tools: php-cs-fixer, phpcs
+          tools: php-cs-fixer, phpcs, composer:${{ inputs.composer-version }}
 
       - name: Install Composer dependancies
         run: composer install --no-progress --no-interaction
@@ -68,7 +72,7 @@ jobs:
           php-version: ${{ inputs.php-version }}
           coverage: none
           extensions: mbstring, intl
-          tools: vimeo/psalm
+          tools: vimeo/psalm, composer:${{ inputs.composer-version }}
 
       - name: Install Composer dependancies
         run: composer install --no-progress --no-interaction

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -13,6 +13,10 @@ on:
       phpunit-config-file:
         required: false
         type: string
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
 
 jobs:
   tests:
@@ -36,7 +40,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2
+          tools: composer:${{ inputs.composer-version }}
           coverage: none
 
       - name: Install dependencies


### PR DESCRIPTION
## Description

Add an optional input parameter "composer-version" to php workflows. 
This allows these actions to be used by repos with plugins that require a specific composer version, such as:  laminas/laminas-dependency-plugin which requires composer <2.3.0

Related issue: [BL-17232](https://dvsa.atlassian.net/browse/BL-17232)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
