### PR TITLE
fix: add env variable for trivy to prevent rate limit

### DIFF
--- a/.github/workflows/terraform-static-full.yaml
+++ b/.github/workflows/terraform-static-full.yaml
@@ -20,6 +20,7 @@ jobs:
           severity: "CRITICAL"
           format: 'table'
           ignore-unfixed: true
+          env: public.ecr.aws/aquasecurity/trivy-db:2
 
   terraform-checkov:
     name: Checkov Scan

--- a/.github/workflows/terraform-static-full.yaml
+++ b/.github/workflows/terraform-static-full.yaml
@@ -20,7 +20,8 @@ jobs:
           severity: "CRITICAL"
           format: 'table'
           ignore-unfixed: true
-          env: public.ecr.aws/aquasecurity/trivy-db:2
+        env: 
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
   terraform-checkov:
     name: Checkov Scan

--- a/.github/workflows/terraform-static.yaml
+++ b/.github/workflows/terraform-static.yaml
@@ -20,6 +20,7 @@ jobs:
           severity: "CRITICAL"
           format: 'table'
           ignore-unfixed: true
+          env: public.ecr.aws/aquasecurity/trivy-db:2
 
   terraform-checkov:
     name: Checkov Scan

--- a/.github/workflows/terraform-static.yaml
+++ b/.github/workflows/terraform-static.yaml
@@ -20,7 +20,8 @@ jobs:
           severity: "CRITICAL"
           format: 'table'
           ignore-unfixed: true
-          env: public.ecr.aws/aquasecurity/trivy-db:2
+        env: 
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
   terraform-checkov:
     name: Checkov Scan

--- a/workflow-templates/terraform-static-full.json
+++ b/workflow-templates/terraform-static-full.json
@@ -1,0 +1,7 @@
+{
+    "name": "DVSA Terraform Static Full Workflow",
+    "description": "Runs a tflint and tf format against any and all .tf files in the repo on a scheduled basis (0600 every Monday morning). Checkov and Trivy will run against the entire repo on a scheduled basis (0600 every Monday morning)",
+    "categories": [
+        "Terraform"
+    ]
+}

--- a/workflow-templates/terraform-static-full.yaml
+++ b/workflow-templates/terraform-static-full.yaml
@@ -1,0 +1,9 @@
+name: terraform-static-full
+
+on:
+  schedule:
+    - cron: '* 6 * * mon'
+
+jobs:
+  terraform-static:
+    uses: dvsa/.github/.github/workflows/terraform-static-full.yaml@main

--- a/workflow-templates/terraform-static-full.yaml
+++ b/workflow-templates/terraform-static-full.yaml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   terraform-static:
-    uses: dvsa/.github/.github/workflows/terraform-static-full.yaml@main
+    uses: dvsa/.github/.github/workflows/terraform-static-full.yaml@v5.0.0

--- a/workflow-templates/terraform-static.json
+++ b/workflow-templates/terraform-static.json
@@ -1,0 +1,7 @@
+{
+    "name": "DVSA Terraform Static Workflow",
+    "description": "Runs a tflint and tf format against any changed .tf files in the PR. Checkov and Trivy will run against the entire repo each time a PR is created/altered",
+    "categories": [
+        "Terraform"
+    ]
+}

--- a/workflow-templates/terraform-static.yaml
+++ b/workflow-templates/terraform-static.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   terraform-static:
-    uses: dvsa/.github/.github/workflows/terraform-static.yaml@main
+    uses: dvsa/.github/.github/workflows/terraform-static.yaml@v5.0.0

--- a/workflow-templates/terraform-static.yaml
+++ b/workflow-templates/terraform-static.yaml
@@ -1,0 +1,8 @@
+name: terraform-static
+
+on:
+  pull_request:
+
+jobs:
+  terraform-static:
+    uses: dvsa/.github/.github/workflows/terraform-static.yaml@main


### PR DESCRIPTION
## Description

Infrequently Trivy will encounter a rate limit issue, adding in the env variable to specify public ECR is a proven workaround for this.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
