### PR TITLE
fix: Allow project path to be empty for whole repo.

### DIFF
--- a/.github/actions/get-vol-app-version/README.md
+++ b/.github/actions/get-vol-app-version/README.md
@@ -10,7 +10,7 @@ The action determines the version of the application by using git commit history
 #### Inputs
 | Name          | Description                             | Required | Default |
 |---------------|-----------------------------------------|----------|---------|
-| `project-path`| The root path of the app project         | `true`   | N/A     |
+| `project-path`| The root path of the app project         | `false`  | N/A     |
 | `ref`         | The commit reference to use as a starting point for the version | `true`   | `"HEAD"` |
 
 #### Outputs

--- a/.github/actions/get-vol-app-version/action.yaml
+++ b/.github/actions/get-vol-app-version/action.yaml
@@ -2,8 +2,8 @@ name: Get app version
 
 inputs:
   project-path:
-    description: The root path of the app project
-    required: true
+    description: The root path of the app project (can be empty)
+    required: false
   ref:
     description: The commit reference to use as a starting point for the version
     required: true
@@ -20,11 +20,15 @@ runs:
     - id: get-version
       shell: bash
       run: |
-        LATEST_APP_COMMIT=$(git rev-list -1 --abbrev-commit ${{ inputs.ref }} -- ${{ inputs.project-path }})
+        if [[ -n "${{ inputs.project-path }}" ]]; then
+          LATEST_APP_COMMIT=$(git rev-list -1 --abbrev-commit ${{ inputs.ref }} -- ${{ inputs.project-path }})
+        else
+          LATEST_APP_COMMIT=$(git rev-list -1 --abbrev-commit ${{ inputs.ref }})
+        fi
 
         COMMIT_RELEASE_VERSION=$(git describe --tags --abbrev=0 $LATEST_APP_COMMIT 2>/dev/null) || true
 
-        LATEST_RELEASE=$(git describe --tags --abbrev=0 ${{ inputs.reference }} 2>/dev/null) || true
+        LATEST_RELEASE=$(git describe --tags --abbrev=0 ${{ inputs.ref }} 2>/dev/null) || true
 
         if [[ $COMMIT_RELEASE_VERSION == $LATEST_RELEASE ]]; then
           TAG=$(git describe --tags --exact-match $LATEST_APP_COMMIT 2>/dev/null) || true


### PR DESCRIPTION
## Description

Allow empty project path in get-app-version
