### PR TITLE
Fix: Update path for TF artifacts archiving

### DIFF
--- a/.github/actions/terraform-action/action.yml
+++ b/.github/actions/terraform-action/action.yml
@@ -62,5 +62,5 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: "${{ inputs.environment }}-${{ inputs.component }}"
-        path: "./plans/${{ inputs.environment }}/${{ inputs.component }}-plan.txt"
+        path: "${{ inputs.terraform_directory }}/plans/${{ inputs.environment }}/${{ inputs.component }}-plan.txt"
         retention-days: 7


### PR DESCRIPTION
## Description

Fix for bug (currently only impacts mot-image-upload-api repo) - 
![Screenshot 2025-02-20 at 14 20 33](https://github.com/user-attachments/assets/2e3283de-87d8-40a9-835c-449bad0521a8)

Set path directory for archive step to include infrastructure path

Test with path set to `./infrastructure` (implemented by mot-image-upload-api repo) - 
![Screenshot 2025-02-20 at 14 26 09](https://github.com/user-attachments/assets/e00db010-5c8a-4d7d-a06f-95fccef51cd7)

Test with path using default value (implemented by mot-trade-api / recalls repos) - 
![Screenshot 2025-02-20 at 14 33 33](https://github.com/user-attachments/assets/c6047c04-b08d-4158-adca-84197a37c556)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
