### PR TITLE
feat: add support for no `max-warnings`

### DIFF
--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -32,4 +32,4 @@ jobs:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}
       - name: Lint
-        run: npm run lint ${{ !inputs.biome && '-- --max-warnings'  || ''}}
+        run: npm run lint ${{ !inputs.biome && '-- --max-warnings ' || ''}}${{ inputs.max-warnings }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -31,8 +31,5 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}
-        
       - name: Lint
-        run: npm run lint ${{ inputs.biome == 'false' }} -- --max-warnings 
-        
-     
+        run: npm run lint ${{ !inputs.biome && '-- --max-warnings'  || ''}}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -32,4 +32,4 @@ jobs:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}
       - name: Lint
-        run: npm run lint ${{ !inputs.biome && '-- --max-warnings ' || ''}}${{ inputs.max-warnings }}
+        run: npm run lint ${{ !inputs.biome && format('-- --max-warnings {0}', inputs.max-warnings) || '' }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -31,9 +31,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}
+        
       - name: Lint
-        if: ${{ !inputs.biome }}
-        run: npm run lint -- --max-warnings ${{ inputs.max-warnings }}
-      - name: Lint with Biome
-        if: ${{ inputs.biome }}
-        run: npm run lint
+        run: npm run lint ${{ inputs.biome == 'false' }} -- --max-warnings 
+        
+     

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -15,6 +15,11 @@ on:
         type: string
         required: false
         default: 'latest'
+      biome:
+        type: boolean
+        required: false
+        default: false
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -27,4 +32,8 @@ jobs:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}
       - name: Lint
+        if: ${{ !inputs.biome }}
         run: npm run lint -- --max-warnings ${{ inputs.max-warnings }}
+      - name: Lint with Biome
+        if: ${{ inputs.biome }}
+        run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ coverage
 
 #IntelliJ Idea
 .idea
+.qodo


### PR DESCRIPTION
## Description

Add a condition to run linitng without `--max-warnings`

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
