### PR TITLE
fix: linting workflow when using biome

### DIFF
--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -6,7 +6,6 @@ on:
       max-warnings:
         required: false
         type: number
-        default: 0
       node-version:
         type: string
         required: false
@@ -32,4 +31,4 @@ jobs:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}
       - name: Lint
-        run: npm run lint ${{ !inputs.biome && format('-- --max-warnings {0}', inputs.max-warnings) || '' }}
+        run: npm run lint ${{ !inputs.biome && inputs.max-warnings != '' && format('-- --max-warnings {0}', inputs.max-warnings) || '' }}

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repository contains shared templates and actions for use throughout the DVS
 
 ## Versions
 
-Currently on Version 5.0.6
+Currently on Version 5.0.10
 
 ```yaml
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v5.0.6
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v5.0.10
 ```
 
 
@@ -107,9 +107,10 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
 
 1. Lint
     - optional argument:
-        - `max-warnings`: Sets how many warnings are allowed. Default is `0`.
-        - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
+        - `max-warnings`: Sets how many warnings are allowed. Only applies when not using Biome. No default value.
+        - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `20.x`.
         - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
+        - `biome`: Boolean flag to indicate if Biome linter is being used. Default is `false`.
 1. Test
     - optional argument:
         - `test-command`: Sets the command used during the Test step. Default is `npm run test`.


### PR DESCRIPTION
## Description


This pull request updates the shared NodeJS lint workflow and documentation to improve flexibility and accuracy. The most important changes include removing the default value for the `max-warnings` input, updating the NodeJS version default to `20.x`, refining the lint command logic to better handle optional arguments, and updating the documentation to reflect these changes.

**Workflow input and command improvements:**

* Removed the default value for the `max-warnings` input in `.github/workflows/nodejs-lint.yaml`, so it is now optional and only used when explicitly provided.
* Updated the lint command logic in `.github/workflows/nodejs-lint.yaml` to only include the `--max-warnings` flag if `max-warnings` is set and Biome is not used.

**Documentation updates:**

* Updated the README to reflect the new version (`v5.0.10`) and changed the default NodeJS version to `20.x`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R113)
* Clarified in the README that `max-warnings` has no default value and is only applied when not using Biome, and documented the new `biome` boolean input.

Related issue: mn/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
