### PR TITLE
fix: skip npm self-upgrade when version unspecified

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -8,10 +8,10 @@ inputs:
     required: false
     default: '18.x'
   npm-version:
-    description: NPM version to be installed and used
+    description: NPM version to install globally before `npm ci`. Leave empty (default) to use the npm bundled with the selected node version. Set to a specific version (e.g. '10.9.7') to pin. Avoid 'latest' — it triggers npm/cli#9151 on Node 22.
     type: string
     required: false
-    default: 'latest'
+    default: ''
 
 runs:
   using: 'composite'
@@ -21,7 +21,9 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
-    - run: npm i -g npm@${{ inputs.npm-version }}
+    - name: Upgrade npm
+      if: inputs.npm-version != ''
+      run: npm i -g npm@${{ inputs.npm-version }}
       shell: bash
     - run: node --version
       shell: bash

--- a/.github/workflows/nodejs-build.yaml
+++ b/.github/workflows/nodejs-build.yaml
@@ -30,7 +30,7 @@ on:
       npm-version:
         type: string
         required: false
-        default: 'latest'
+        default: ''
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@v5.0.4
+        uses: dvsa/.github/.github/actions/install-deps@v5.0.11
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-lint.yaml
+++ b/.github/workflows/nodejs-lint.yaml
@@ -13,7 +13,7 @@ on:
       npm-version:
         type: string
         required: false
-        default: 'latest'
+        default: ''
       biome:
         type: boolean
         required: false
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@v5.0.4
+        uses: dvsa/.github/.github/actions/install-deps@v5.0.11
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/.github/workflows/nodejs-test.yaml
+++ b/.github/workflows/nodejs-test.yaml
@@ -14,7 +14,7 @@ on:
       npm-version:
         required: false
         type: string
-        default: 'latest'
+        default: ''
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: dvsa/.github/.github/actions/install-deps@v4.1.1
+        uses: dvsa/.github/.github/actions/install-deps@v5.0.11
         with:
           node-version: ${{ inputs.node-version }}
           npm-version: ${{ inputs.npm-version }}

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
     - optional argument:
         - `max-warnings`: Sets how many warnings are allowed. Only applies when not using Biome. No default value.
         - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `20.x`.
-        - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
+        - `npm-version`: Global npm version to install before `npm ci`. Default is `''` (use the npm bundled with the selected node version). Avoid `'latest'` — triggers npm/cli#9151 on Node 22.
         - `biome`: Boolean flag to indicate if Biome linter is being used. Default is `false`.
 1. Test
     - optional argument:
         - `test-command`: Sets the command used during the Test step. Default is `npm run test`.
         - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
-        - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
+        - `npm-version`: Global npm version to install before `npm ci`. Default is `''` (use the npm bundled with the selected node version). Avoid `'latest'` — triggers npm/cli#9151 on Node 22.
 1. Security
     - required secret `SNYK_TOKEN` requires the organization or repo Snyk token secret
     - optional argument `args` allows passing in any extra args to the Snyk command. Note, the default behavior is to test all projects including all dev dependencies. If you don't want to test dev dependencies, pass in args: `--all-projects` to override the default args.
@@ -130,7 +130,7 @@ Publishing to NPM requires permissions and the relevant token to be stored in th
         - `retention-days`: How many days to save the archive for if it's stored. (upload-artifact: `true`). Default is `7` days.
         - `build-command`: The command to run to build the project. Defaults to `npm run package`.
         - `node-version`: Defines the version of NodeJS is used for actions/install-deps. Default is `18.x`.
-        - `npm-version`: Defines the version of NPM that is used for actions/install-deps. Default is `latest`.
+        - `npm-version`: Global npm version to install before `npm ci`. Default is `''` (use the npm bundled with the selected node version). Avoid `'latest'` — triggers npm/cli#9151 on Node 22.
 1. Upload to s3
 
     Workflow downloads the archive created from the build workflow and pushes it to s3 with the commit id as a tag. Default only running on master branch. See examples before for more information.


### PR DESCRIPTION
## Summary

The shared `install-deps` composite action runs `npm i -g npm@latest` unconditionally on every job. This currently fails on Node 22 with:

```
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

Tracked upstream as [npm/cli#9151](https://github.com/npm/cli/issues/9151). Open with no fix or ETA.

**Impact:** every DVSA Node CI pipeline that uses `nodejs-lint.yaml` / `nodejs-test.yaml` / `nodejs-build.yaml` without setting an explicit `npm-version` has been red since ~2026-03-04. v5.0.10 is byte-identical to v5.0.4 for `install-deps/action.yaml`, so consumers cannot escape by bumping their caller tag.

## Approach

- Change the default of `npm-version` from `'latest'` to `''`
- Gate the `npm i -g` step with `if: inputs.npm-version != ''`
- Empty string means "use the npm bundled with the selected node version" — strictly safer than self-upgrading to whatever is on the registry
- Explicit version pins (e.g. `'10.9.7'`) are unchanged
- Anyone explicitly passing `'latest'` still gets the upgrade attempt; that's an explicit ask we honor

The three reusable workflows (`nodejs-{lint,test,build}.yaml`) also get their internal `install-deps@vX.Y.Z` pin bumped to `v5.0.11` so that consumers who bump their caller tag actually pick up the fix. Forward-referencing `v5.0.11` is fine because action refs resolve at run time, not commit time — once the tag is cut on the merge commit the references resolve consistently.

### Behavior matrix

| Consumer setting | Before | After |
|---|---|---|
| No `npm-version` set | 💥 `latest` is broken | ✅ skip upgrade, use node-bundled npm |
| `npm-version: '10.9.7'` | ✅ works | ✅ unchanged |
| `npm-version: 'latest'` (explicit) | 💥 broken | 💥 still broken (explicit ask) |
| `npm-version: ''` | would fail (`npm@`) | ✅ skipped |

The only behavior change is for consumers relying on the old `latest` default — and they're currently red anyway, so "change" = "unbroken".

## Release / rollout

After merge, this commit needs to be tagged **v5.0.11** for the forward refs in the workflows to resolve. Consumers can then bump their caller (e.g. `nodejs-lint.yaml@v5.0.10` → `@v5.0.11`) and stop hitting the regression.

## Test plan

- [ ] CI on this PR passes
- [ ] After merge: tag `v5.0.11` on the merge commit
- [ ] Re-run CI on `dvsa/inr-erru-middleware` PR #293 after bumping its caller tag to `@v5.0.11` — confirm `lint` and `test` jobs go green