### PR TITLE
chore: remove trivy

### DIFF
--- a/.github/workflows/terraform-static-full.yaml
+++ b/.github/workflows/terraform-static-full.yaml
@@ -6,25 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  terraform-trivy:
-    name: Trivy Scan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Scan
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          exit-code: 1
-          scan-ref: "."
-          scan-type: "config" # scan terraform
-          severity: "CRITICAL"
-          format: 'table'
-          ignore-unfixed: true
-        env: 
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-
   terraform-checkov:
     name: Checkov Scan
     permissions:

--- a/.github/workflows/terraform-static.yaml
+++ b/.github/workflows/terraform-static.yaml
@@ -4,25 +4,6 @@ on:
   workflow_call:
 
 jobs:
-  terraform-trivy:
-    name: Trivy Scan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Scan
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          exit-code: 1
-          scan-ref: "."
-          scan-type: "config" # scan terraform
-          severity: "CRITICAL"
-          format: 'table'
-          ignore-unfixed: true
-        env: 
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-
   terraform-checkov:
     name: Checkov Scan
     permissions:

--- a/README.md
+++ b/README.md
@@ -372,9 +372,9 @@ IDE integration matches those on the Snyk website.
 
 This workflow can be used to check against known configuration vulnerabilities, formatting and linting issues within the terraform code. It will also scan any containers (incl. dev containers) that exist within that repo.
 
-This is configured to run on PR to help with reviews of the terraform code quality, and it does not need any inputs. They Trivy scan, Checkov scan and changed file scan run in parrallel.
+This is configured to run on PR to help with reviews of the terraform code quality, and it does not need any inputs. They Checkov scan and changed file scan run in parrallel.
 
-From a security scan perspective the Trivy and Checkov scans will scan recursively any configuration files from the root of the repo. It may inadvertantly scan any other files that fall within the remit of the trivy/checkov scans as well.
+From a security scan perspective the Checkov scans will scan recursively any configuration files from the root of the repo. It may inadvertantly scan any other files that fall within the remit of the checkov scans as well.
 
 The repo will detect any changed files in the PR and anything with a .tf extension it will run terraform fmt -check as well as tflint. Through a quirk of tflint it will actually scan the entire directory even if --filter is used and output any global errors (e.g. invalid input errors). Any global errors will override any file based filters, these will need to be corrected before any other advisories can be seen.
 
@@ -382,15 +382,9 @@ To preven this automatically running the on pull request configuration has been 
 
 ### Steps
 
-  - Trivy Scan
-      - Checkout Project
-          - Checkout branch from GitHub.
-      - Run Trivy action
-          - Run trivy scan from `.` highlighting critical vulnerabilities
   - Checkov Scan
       - Checkout Project
           - Checkout branch from GitHub.
-      - Run Trivy action
           - Run Checkov scan from `.` highlighting critical vulnerabilities
 
     - Check modified files
@@ -413,17 +407,9 @@ None
 This workflow follows a similar function as the terraform-static.yaml workflow but does not only run on the changes files in the repo but runs globally against all configuration files.
 
 ### Steps
-
-  - Trivy Scan
-      - Checkout Project
-          - Checkout branch from GitHub.
-      - Run Trivy action
-          - Run trivy scan from `.` highlighting critical vulnerabilities
   - Checkov Scan
       - Checkout Project
           - Checkout branch from GitHub.
-      - Run Trivy action
-          - Run Checkov scan from `.` highlighting critical vulnerabilities
   - Terraform fmt check
       - Checkout Project
           - Checkout branch from GitHub.

--- a/workflow-templates/terraform-static-full.properties.json
+++ b/workflow-templates/terraform-static-full.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "DVSA Terraform Static Full Workflow",
-    "description": "Runs a tflint and tf format against any and all .tf files in the repo on a scheduled basis (0600 every Monday morning). Checkov and Trivy will run against the entire repo on a scheduled basis (0600 every Monday morning)",
+    "description": "Runs a tflint and tf format against any and all .tf files in the repo on a scheduled basis (0600 every Monday morning). Checkov will run against the entire repo on a scheduled basis (0600 every Monday morning)",
     "categories": [
         "Terraform"
     ]

--- a/workflow-templates/terraform-static.properties.json
+++ b/workflow-templates/terraform-static.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "DVSA Terraform Static Workflow",
-    "description": "Runs a tflint and tf format against any changed .tf files in the PR. Checkov and Trivy will run against the entire repo each time a PR is created/altered",
+    "description": "Runs a tflint and tf format against any changed .tf files in the PR. Checkov will run against the entire repo each time a PR is created/altered",
     "categories": [
         "Terraform"
     ]


### PR DESCRIPTION
## Description

As per title, the number of security impacting incidents Trivy has had means that it no longer sits without our appetite for risk.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
